### PR TITLE
support pkg-config.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/kytea.pc

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,1 +1,4 @@
 SUBDIRS = src data
+
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = kytea.pc

--- a/configure.ac
+++ b/configure.ac
@@ -7,6 +7,7 @@ AC_CONFIG_SRCDIR([src/lib/kytea.cpp])
 AC_CONFIG_HEADERS([src/include/kytea/config.h])
 AC_CONFIG_FILES([
     Makefile
+    kytea.pc
     src/Makefile
     src/include/Makefile
     src/lib/Makefile

--- a/kytea.pc.in
+++ b/kytea.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+bindir=@bindir@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: KyTea
+Description: KyTea is a general toolkit developed for analyzing text.
+Version: @VERSION@
+Cflags: -I${includedir}
+Libs: -L${libdir} -lkytea


### PR DESCRIPTION
If KyTea supports pkg-confg (kytea.pc), KyTea users can get CFLAGS and LIBS for KyTea easily.
