### PR TITLE
Fixed incorrect variable names of command line parameters.

### DIFF
--- a/src/bin/run-kytea.cpp
+++ b/src/bin/run-kytea.cpp
@@ -22,7 +22,7 @@ using namespace std;
 using namespace kytea;
 
 // trains a pronunciation estimation model using a corpus and a dictionary
-int main(int argv, const char **argc) {
+int main(int argc, const char **argv) {
 
 #ifndef KYTEA_SAFE
     try {
@@ -30,7 +30,7 @@ int main(int argv, const char **argc) {
         KyteaConfig * config = new KyteaConfig;
         config->setDebug(0);
         config->setOnTraining(false);
-        config->parseRunCommandLine(argv, argc);
+        config->parseRunCommandLine(argc, argv);
 
         Kytea kytea(config);
         kytea.analyze();

--- a/src/bin/train-kytea.cpp
+++ b/src/bin/train-kytea.cpp
@@ -23,7 +23,7 @@ using namespace std;
 using namespace kytea;
 
 // trains a KyTea model
-int main(int argv, const char **argc) {
+int main(int argc, const char **argv) {
 
 #ifndef KYTEA_SAFE
     try {
@@ -31,7 +31,7 @@ int main(int argv, const char **argc) {
         KyteaConfig * config = new KyteaConfig;
         config->setDebug(1);
         config->setOnTraining(true);
-        config->parseTrainCommandLine(argv, argc);
+        config->parseTrainCommandLine(argc, argv);
 
         Kytea kytea(config);
         kytea.trainAll();

--- a/src/test/test-kytea.cpp
+++ b/src/test/test-kytea.cpp
@@ -36,7 +36,7 @@
 
 using namespace std;
 
-int main(int argv, char **argc) {
+int main(int argc, char **argv) {
     kytea::KyteaTest test_kytea;
     kytea::TestAnalysis test_analysis;
     kytea::TestCorpusIO test_corpusio;


### PR DESCRIPTION
This is just a minor issue. The order of parameters in the main function is backward at some places. It should look like the following:

```
int main(int argc, char **argv)
```
