### PR TITLE
Fix automake errors

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -25,10 +25,6 @@ AC_CONFIG_FILES([
 ])
 AC_CONFIG_MACRO_DIR([m4])
 
-# Intialize automake
-AM_INIT_AUTOMAKE([-Wall])
-AM_PROG_AR
-
 AC_PROG_LIBTOOL
 
 # set CFLAGS and CXXFLAGS for maximal optimization


### PR DESCRIPTION
HEAD of KyTea is broken. This is because AM_INIT_AUTOMAKE is called twice. This request fixes the build errors. Tested on Ubuntu 14.04 and OS X 10.9.4.
