### PR TITLE
Add const to member functions in StringUtil and its derived classes

### DIFF
--- a/src/include/kytea/string-util.h
+++ b/src/include/kytea/string-util.h
@@ -57,18 +57,21 @@ public:
         if(normMap_) delete normMap_;    
     }
 
-    // map a std::string to a character
+    // Map a std::string to a character.
+    // If `add` is true, this operation changes the private members. That means,
+    // an external synchronization is required.
     virtual KyteaChar mapChar(const std::string & str, bool add = true) = 0;
-    virtual std::string showChar(KyteaChar c) = 0;
 
-    std::string showString(const KyteaString & c) {
+    virtual std::string showChar(KyteaChar c) const = 0;
+
+    std::string showString(const KyteaString & c) const {
         std::ostringstream buff;
         for(unsigned i = 0; i < c.length(); i++)
             buff << showChar(c[i]);
         return buff.str();
     }
 
-    std::string showEscapedString(const KyteaString & c, const KyteaString & spec, const std::string & bs) {
+    std::string showEscapedString(const KyteaString & c, const KyteaString & spec, const std::string & bs) const {
         std::ostringstream buff;
         for(unsigned i = 0; i < c.length(); i++) {
             if(spec.contains(c[i]))
@@ -78,16 +81,17 @@ public:
         return buff.str();
     }
 
-    // map an unparsed std::string to a KyteaString
+    // Map an unparsed std::string to a KyteaString.
+    // Note that this operation requires an external synchronization.
     virtual KyteaString mapString(const std::string & str) = 0;
 
     // get the type of a character
     virtual CharType findType(const std::string & str) = 0;
-    virtual CharType findType(KyteaChar c) = 0;
+    virtual CharType findType(KyteaChar c) const = 0;
 
     // return the encoding provided by this util
-    virtual Encoding getEncoding() = 0;
-    virtual const char* getEncodingString() = 0;
+    virtual Encoding getEncoding() const = 0;
+    virtual const char* getEncodingString() const = 0;
     
     // transform to or from a character std::string
     virtual void unserialize(const std::string & str) = 0;
@@ -101,12 +105,12 @@ public:
     void checkEqual(const StringUtil & rhs) const;
 
     // parse an integer or float
-    int parseInt(const char* str);
-    double parseFloat(const char* str);
+    int parseInt(const char* str) const;
+    double parseFloat(const char* str) const;
 
 
     // get a std::string of character types
-    std::string getTypeString(const KyteaString& str) {
+    std::string getTypeString(const KyteaString& str) const {
         std::ostringstream buff;
         for(unsigned i = 0; i < str.length(); i++)
             buff << findType(str[i]);
@@ -138,22 +142,22 @@ public:
     
     // map a std::string to a character
     KyteaChar mapChar(const std::string & str, bool add = true);
-    std::string showChar(KyteaChar c);
+    std::string showChar(KyteaChar c) const;
 
-    CharType findType(KyteaChar c);
+    CharType findType(KyteaChar c) const;
 
     GenericMap<KyteaChar,KyteaChar> * getNormMap();
 
-    bool badu(char val) { return ((val ^ maskl1) & maskl2); }
+    bool badu(char val) const { return ((val ^ maskl1) & maskl2); }
     KyteaString mapString(const std::string & str);
 
     // find the type of a unicode character
     CharType findType(const std::string & str);
 
-    Encoding getEncoding() { return ENCODING_UTF8; }
-    const char* getEncodingString() { return "utf8"; }
+    Encoding getEncoding() const { return ENCODING_UTF8; }
+    const char* getEncodingString() const { return "utf8"; }
 
-    const std::vector<std::string> & getCharNames() { return charNames_; }
+    const std::vector<std::string> & getCharNames() const { return charNames_; }
 
     // transform to or from a character std::string
     void unserialize(const std::string & str);
@@ -172,7 +176,7 @@ public:
     ~StringUtilEuc() { }
 
     KyteaChar mapChar(const std::string & str, bool add = true);
-    std::string showChar(KyteaChar c);
+    std::string showChar(KyteaChar c) const;
     
     GenericMap<KyteaChar,KyteaChar> * getNormMap();
 
@@ -181,11 +185,11 @@ public:
 
     // get the type of a character
     CharType findType(const std::string & str);
-    CharType findType(KyteaChar c);
+    CharType findType(KyteaChar c) const;
 
     // return the encoding provided by this util
-    Encoding getEncoding();
-    const char* getEncodingString();
+    Encoding getEncoding() const;
+    const char* getEncodingString() const;
     
     // transform to or from a character std::string
     void unserialize(const std::string & str);
@@ -206,18 +210,18 @@ public:
     KyteaChar mapChar(const std::string & str, bool add = true);
     GenericMap<KyteaChar,KyteaChar> * getNormMap();
 
-    std::string showChar(KyteaChar c);
+    std::string showChar(KyteaChar c) const;
     
     // map an unparsed std::string to a KyteaString
     KyteaString mapString(const std::string & str);
 
     // get the type of a character
     CharType findType(const std::string & str);
-    CharType findType(KyteaChar c);
+    CharType findType(KyteaChar c) const;
 
     // return the encoding provided by this util
-    Encoding getEncoding();
-    const char* getEncodingString();
+    Encoding getEncoding() const;
+    const char* getEncodingString() const;
     
     // transform to or from a character std::string
     void unserialize(const std::string & str);

--- a/src/lib/string-util.cpp
+++ b/src/lib/string-util.cpp
@@ -39,14 +39,14 @@ void StringUtil::checkEqual(const StringUtil & rhs) const {
 }
 
 // parse an integer or float
-int StringUtil::parseInt(const char* str) {
+int StringUtil::parseInt(const char* str) const {
     char* endP;
     int ret = strtol(str, &endP, 10);
     if(endP == str)
         THROW_ERROR("Bad integer value '" << str << "'");
     return ret;
 }
-double StringUtil::parseFloat(const char* str) {
+double StringUtil::parseFloat(const char* str) const {
     char* endP;
     double ret = strtod(str, &endP);
     if(endP == str)
@@ -126,7 +126,7 @@ KyteaChar StringUtilUtf8::mapChar(const string & str, bool add) {
     return ret;
 }
 
-string StringUtilUtf8::showChar(KyteaChar c) {
+string StringUtilUtf8::showChar(KyteaChar c) const {
 #ifdef KYTEA_SAFE
     if(c >= charNames_.size())
         THROW_ERROR("FATAL: Index out of bounds in showChar");
@@ -134,7 +134,7 @@ string StringUtilUtf8::showChar(KyteaChar c) {
     return charNames_[c];
 }
 
-StringUtil::CharType StringUtilUtf8::findType(KyteaChar c) {
+StringUtil::CharType StringUtilUtf8::findType(KyteaChar c) const {
     return charTypes_[c];
 }
 
@@ -268,7 +268,7 @@ KyteaChar StringUtilEuc::mapChar(const string & str, bool add) {
     return ret;
 }
 
-string StringUtilEuc::showChar(KyteaChar c) {
+string StringUtilEuc::showChar(KyteaChar c) const {
     if(c < 0x8E) {
         char arr[2] = { c, 0 };
         string ret(arr);
@@ -304,7 +304,7 @@ KyteaString StringUtilEuc::mapString(const string & str) {
 StringUtil::CharType StringUtilEuc::findType(const string & str) {
     return findType(mapChar(str));
 }
-StringUtil::CharType StringUtilEuc::findType(KyteaChar c) {
+StringUtil::CharType StringUtilEuc::findType(KyteaChar c) const {
     unsigned char c1 = euc1(c), c2 = euc2(c);
     // digits (hankaku/zenkaku)
     if((c2 >= 0x30 && c2 <= 0x39) || (c1 == 0xA3 && c2 >= 0xB0 && c2 <= 0xB9))
@@ -333,8 +333,8 @@ StringUtil::CharType StringUtilEuc::findType(KyteaChar c) {
 }
 
 // return the encoding provided by this util
-StringUtil::Encoding StringUtilEuc::getEncoding() { return StringUtil::ENCODING_EUC; } 
-const char* StringUtilEuc::getEncodingString() { return "euc"; }
+StringUtil::Encoding StringUtilEuc::getEncoding() const { return StringUtil::ENCODING_EUC; }
+const char* StringUtilEuc::getEncodingString() const { return "euc"; }
 
 // transform to or from a character string
 void StringUtilEuc::unserialize(const string & str) {  }
@@ -378,7 +378,7 @@ KyteaChar StringUtilSjis::mapChar(const string & str, bool add) {
     return ret;
 }
 
-string StringUtilSjis::showChar(KyteaChar c) {
+string StringUtilSjis::showChar(KyteaChar c) const {
     if(c < 0xFF) {
         char arr[2] = { c, 0 };
         string ret(arr);
@@ -415,7 +415,7 @@ KyteaString StringUtilSjis::mapString(const string & str) {
 StringUtil::CharType StringUtilSjis::findType(const string & str) {
     return findType(mapChar(str));
 }
-StringUtil::CharType StringUtilSjis::findType(KyteaChar c) {
+StringUtil::CharType StringUtilSjis::findType(KyteaChar c) const {
     unsigned char c1 = sjis1(c), c2 = sjis2(c);
     // digits (hankaku/zenkaku)
     if((c1 == 0 && c2 >= 0x30 && c2 <= 0x39) || (c1 == 0x82 && c2 >= 0x4F && c2 <= 0x58))
@@ -459,8 +459,8 @@ KyteaString StringUtil::normalize(const KyteaString & str) {
 }
 
 // return the encoding provided by this util
-StringUtil::Encoding StringUtilSjis::getEncoding() { return StringUtil::ENCODING_SJIS; } 
-const char* StringUtilSjis::getEncodingString() { return "sjis"; }
+StringUtil::Encoding StringUtilSjis::getEncoding() const { return StringUtil::ENCODING_SJIS; }
+const char* StringUtilSjis::getEncodingString() const { return "sjis"; }
 
 // transform to or from a character string
 void StringUtilSjis::unserialize(const string & str) {  }


### PR DESCRIPTION
In particular, explicitly adding const to StringUtil::showString would be
important because it could be used a lot by clients when they want to get
a std::string object from the internal representation of KyTea's string.

Also, add comments regarding the thread safety to mapChar and mapString.
