### PR TITLE
Prevent to install api-example program

### DIFF
--- a/src/api/Makefile.am
+++ b/src/api/Makefile.am
@@ -5,7 +5,7 @@ KYTH =
 
 AM_CPPFLAGS = -I$(srcdir)/../include -DPKGDATADIR='"$(pkgdatadir)"'
 
-bin_PROGRAMS = api-example
+noinst_PROGRAMS = api-example
 
 api_example_SOURCES = api-example.cpp ${KYTH}
 api_example_LDADD = ../lib/libkytea.la


### PR DESCRIPTION
It is only usable in build tree, should not be installed.