### PR TITLE
Build windows binary on Appvayor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,30 @@
+version: 1.0.{build}
+image: Visual Studio 2017
+configuration: Release
+platform:
+- x64
+- Win32
+build:
+  project: build-win\kytea.sln
+  parallel: true
+  verbosity: minimal
+
+after_build:
+    - cd %APPVEYOR_BUILD_FOLDER%\
+    - 7z a kytea-win-%PLATFORM%.zip %APPVEYOR_BUILD_FOLDER%\build-win\build-win\Release*\kytea.exe
+    - 7z a kytea-win-%PLATFORM%.zip %APPVEYOR_BUILD_FOLDER%\build-win\build-win\Release*\train-kytea.exe
+    - 7z a kytea-win-%PLATFORM%.zip %APPVEYOR_BUILD_FOLDER%\build-win\build-win\Release*\lib
+
+artifacts:
+- path: '*.zip'
+  name: kytea-win
+deploy:
+  description: 'kytea-win'
+  provider: GitHub
+  auth_token:
+    secure: WcAHkON2wIKV1F/fwpQgUsk45iZilZfIb+9dIxX0GnneMFCdal/8FpM8gZmPO/N4
+  artifact: kytea-win
+  draft: false
+  prerelease: false
+  on:
+    appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ deploy:
   description: 'kytea-win'
   provider: GitHub
   auth_token:
-    secure: WcAHkON2wIKV1F/fwpQgUsk45iZilZfIb+9dIxX0GnneMFCdal/8FpM8gZmPO/N4
+    secure: REPLACE-ME
   artifact: kytea-win
   draft: false
   prerelease: false

--- a/build-win/kytea.vcxproj
+++ b/build-win/kytea.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,6 +30,7 @@
     <ProjectGuid>{FD77500A-9D00-A278-647D-03F972E4BE94}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>kytea</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
@@ -37,22 +38,22 @@
     <ConfigurationType>Application</ConfigurationType>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Optimize|Win32'">
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Optimize|x64'">
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings" />

--- a/build-win/libkytea.vcxproj
+++ b/build-win/libkytea.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,6 +30,7 @@
     <ProjectGuid>{6803C738-5FB3-3852-2C07-4954A486D60F}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>libkytea</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
@@ -37,22 +38,22 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Optimize|Win32'">
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Optimize|x64'">
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings" />

--- a/build-win/libkytea.vcxproj.filters
+++ b/build-win/libkytea.vcxproj.filters
@@ -1,1 +1,95 @@
-<?xml version="1.0" encoding="utf-8"?><Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003"><ItemGroup><Filter Include=".."><UniqueIdentifier>{739DB09A-CC57-A953-A6CF-F64FA08E4FA7}</UniqueIdentifier></Filter><Filter Include="..\src"><UniqueIdentifier>{8CDEE807-BC53-E450-C8B8-4DEBB66742D4}</UniqueIdentifier></Filter><Filter Include="..\src\lib"><UniqueIdentifier>{2739B19F-16DF-601C-060A-FF86F6A40045}</UniqueIdentifier></Filter><Filter Include="..\src\lib\liblinear"><UniqueIdentifier>{B0AEC634-2F64-69F4-4DAE-C71F7A9BD208}</UniqueIdentifier></Filter><Filter Include="..\src\lib\liblinear\blas"><UniqueIdentifier>{DD653FF0-9711-24FA-4784-B8422839B4CB}</UniqueIdentifier></Filter></ItemGroup><ItemGroup><None Include="kytea.gyp"/><ClCompile Include="..\src\lib\kytea.cpp"><Filter>..\src\lib</Filter></ClCompile><ClCompile Include="..\src\lib\kytea-model.cpp"><Filter>..\src\lib</Filter></ClCompile><ClCompile Include="..\src\lib\dictionary.cpp"><Filter>..\src\lib</Filter></ClCompile><ClCompile Include="..\src\lib\feature-lookup.cpp"><Filter>..\src\lib</Filter></ClCompile><ClCompile Include="..\src\lib\kytea-lm.cpp"><Filter>..\src\lib</Filter></ClCompile><ClCompile Include="..\src\lib\corpus-io.cpp"><Filter>..\src\lib</Filter></ClCompile><ClCompile Include="..\src\lib\feature-io.cpp"><Filter>..\src\lib</Filter></ClCompile><ClCompile Include="..\src\lib\string-util.cpp"><Filter>..\src\lib</Filter></ClCompile><ClCompile Include="..\src\lib\model-io.cpp"><Filter>..\src\lib</Filter></ClCompile><ClCompile Include="..\src\lib\kytea-config.cpp"><Filter>..\src\lib</Filter></ClCompile><ClCompile Include="..\src\lib\liblinear\tron.cpp"><Filter>..\src\lib\liblinear</Filter></ClCompile><ClInclude Include="..\src\lib\liblinear\linear.h"><Filter>..\src\lib\liblinear</Filter></ClInclude><ClInclude Include="..\src\lib\liblinear\tron.h"><Filter>..\src\lib\liblinear</Filter></ClInclude><ClCompile Include="..\src\lib\liblinear\linear.cpp"><Filter>..\src\lib\liblinear</Filter></ClCompile><ClInclude Include="..\src\lib\liblinear\blas\blas.h"><Filter>..\src\lib\liblinear\blas</Filter></ClInclude><ClCompile Include="..\src\lib\liblinear\blas\daxpy.c"><Filter>..\src\lib\liblinear\blas</Filter></ClCompile><ClCompile Include="..\src\lib\liblinear\blas\ddot.c"><Filter>..\src\lib\liblinear\blas</Filter></ClCompile><ClCompile Include="..\src\lib\liblinear\blas\dnrm2.c"><Filter>..\src\lib\liblinear\blas</Filter></ClCompile><ClCompile Include="..\src\lib\liblinear\blas\dscal.c"><Filter>..\src\lib\liblinear\blas</Filter></ClCompile><ClInclude Include="..\src\lib\liblinear\blas\blasp.h"><Filter>..\src\lib\liblinear\blas</Filter></ClInclude></ItemGroup></Project>
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="..">
+      <UniqueIdentifier>{739DB09A-CC57-A953-A6CF-F64FA08E4FA7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="..\src">
+      <UniqueIdentifier>{8CDEE807-BC53-E450-C8B8-4DEBB66742D4}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="..\src\lib">
+      <UniqueIdentifier>{2739B19F-16DF-601C-060A-FF86F6A40045}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="..\src\lib\liblinear">
+      <UniqueIdentifier>{B0AEC634-2F64-69F4-4DAE-C71F7A9BD208}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="..\src\lib\liblinear\blas">
+      <UniqueIdentifier>{DD653FF0-9711-24FA-4784-B8422839B4CB}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="kytea.gyp" />
+    <ClCompile Include="..\src\lib\kytea.cpp">
+      <Filter>..\src\lib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib\kytea-model.cpp">
+      <Filter>..\src\lib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib\dictionary.cpp">
+      <Filter>..\src\lib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib\feature-lookup.cpp">
+      <Filter>..\src\lib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib\kytea-lm.cpp">
+      <Filter>..\src\lib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib\corpus-io.cpp">
+      <Filter>..\src\lib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib\feature-io.cpp">
+      <Filter>..\src\lib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib\string-util.cpp">
+      <Filter>..\src\lib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib\model-io.cpp">
+      <Filter>..\src\lib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib\kytea-config.cpp">
+      <Filter>..\src\lib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib\liblinear\tron.cpp">
+      <Filter>..\src\lib\liblinear</Filter>
+    </ClCompile>
+    <ClInclude Include="..\src\lib\liblinear\linear.h">
+      <Filter>..\src\lib\liblinear</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\lib\liblinear\tron.h">
+      <Filter>..\src\lib\liblinear</Filter>
+    </ClInclude>
+    <ClCompile Include="..\src\lib\liblinear\linear.cpp">
+      <Filter>..\src\lib\liblinear</Filter>
+    </ClCompile>
+    <ClInclude Include="..\src\lib\liblinear\blas\blas.h">
+      <Filter>..\src\lib\liblinear\blas</Filter>
+    </ClInclude>
+    <ClCompile Include="..\src\lib\liblinear\blas\daxpy.c">
+      <Filter>..\src\lib\liblinear\blas</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib\liblinear\blas\ddot.c">
+      <Filter>..\src\lib\liblinear\blas</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib\liblinear\blas\dnrm2.c">
+      <Filter>..\src\lib\liblinear\blas</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib\liblinear\blas\dscal.c">
+      <Filter>..\src\lib\liblinear\blas</Filter>
+    </ClCompile>
+    <ClInclude Include="..\src\lib\liblinear\blas\blasp.h">
+      <Filter>..\src\lib\liblinear\blas</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\src\lib\corpus-io-eda.cpp" />
+    <ClCompile Include="..\src\lib\corpus-io-full.cpp" />
+    <ClCompile Include="..\src\lib\corpus-io-part.cpp" />
+    <ClCompile Include="..\src\lib\corpus-io-prob.cpp" />
+    <ClCompile Include="..\src\lib\corpus-io-raw.cpp" />
+    <ClCompile Include="..\src\lib\corpus-io-tokenized.cpp" />
+    <ClCompile Include="..\src\lib\general-io.cpp" />
+    <ClCompile Include="..\src\lib\kytea-string.cpp" />
+    <ClCompile Include="..\src\lib\kytea-struct.cpp" />
+    <ClCompile Include="..\src\lib\kytea-util.cpp" />
+  </ItemGroup>
+</Project>

--- a/build-win/train-kytea.vcxproj
+++ b/build-win/train-kytea.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,6 +30,7 @@
     <ProjectGuid>{B3FCFDDB-D791-DEB4-80C8-696E1C197E8A}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>train-kytea</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
@@ -37,22 +38,22 @@
     <ConfigurationType>Application</ConfigurationType>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Optimize|Win32'">
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Optimize|x64'">
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings" />


### PR DESCRIPTION
This PR adds building and releasing windows binary. After pushing tag on GitHub, Windows binaries are deployed as follows:
https://github.com/chezou/kytea/releases/tag/0.4.7

Note that, this deployment doesn't include any model.