### PR TITLE
Migrate to C++14

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.59])
-AC_INIT([kytea], [0.4.7], [kytea@phontron.com])
+AC_INIT([kytea], [0.4.8], [kytea@phontron.com])
 
 # Intialize automake
 AM_INIT_AUTOMAKE([-Wall] [foreign])
@@ -33,7 +33,7 @@ if test -n "${CXXFLAGS}"; then
 fi
 AC_PROG_CXX
 if test X$user_set_cxxflags != Xyes; then
-  CXXFLAGS="-g -Wall -O3"
+  CXXFLAGS="-std=c++14 -g -Wall -O3"
 fi
 if test -n "${CFLAGS}"; then
   user_set_cflags=yes
@@ -60,8 +60,6 @@ AC_HEADER_STDBOOL
 AC_C_INLINE
 AC_TYPE_SIZE_T
 
-# Check to make sure that we have unordered_map
 AC_LANG([C++])
-AC_CHECK_HEADERS([boost/tr1/unordered_map.hpp tr1/unordered_map ext/hash_map], break)
 
 AC_OUTPUT

--- a/src/include/kytea/config.h
+++ b/src/include/kytea/config.h
@@ -4,14 +4,8 @@
 /* Enable quantizing */
 #define DISABLE_QUANTIZE 0
 
-/* Define to 1 if you have the <boost/tr1/unordered_map.hpp> header file. */
-/* #undef HAVE_BOOST_TR1_UNORDERED_MAP_HPP */
-
 /* Define to 1 if you have the <dlfcn.h> header file. */
 #define HAVE_DLFCN_H 1
-
-/* Define to 1 if you have the <ext/hash_map> header file. */
-/* #undef HAVE_EXT_HASH_MAP */
 
 /* Define to 1 if you have the <inttypes.h> header file. */
 #define HAVE_INTTYPES_H 1
@@ -40,17 +34,13 @@
 /* Define to 1 if you have the <sys/types.h> header file. */
 #define HAVE_SYS_TYPES_H 1
 
-/* Define to 1 if you have the <tr1/unordered_map> header file. */
-/* #undef HAVE_TR1_UNORDERED_MAP */
-
 /* Define to 1 if you have the <unistd.h> header file. */
 #define HAVE_UNISTD_H 1
 
 /* Define to 1 if the system has the type `_Bool'. */
 #define HAVE__BOOL 1
 
-/* Define to the sub-directory in which libtool stores uninstalled libraries.
-   */
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
 #define LT_OBJDIR ".libs/"
 
 /* Name of package */
@@ -63,7 +53,7 @@
 #define PACKAGE_NAME "kytea"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "kytea 0.4.6"
+#define PACKAGE_STRING "kytea 0.4.8"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "kytea"
@@ -72,13 +62,13 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "0.4.6"
+#define PACKAGE_VERSION "0.4.8"
 
 /* Define to 1 if you have the ANSI C header files. */
 #define STDC_HEADERS 1
 
 /* Version number of package */
-#define VERSION "0.4.6"
+#define VERSION "0.4.8"
 
 /* Define to `__inline__' or `__inline' if that's what the C compiler
    calls it, or to nothing if 'inline' is not supported under any name.  */

--- a/src/include/kytea/kytea-struct.h
+++ b/src/include/kytea/kytea-struct.h
@@ -25,52 +25,14 @@
 #include <kytea/config.h>
 #include <kytea/kytea-string.h>
 #include <string>
-#include <map>
+#include <unordered_map>
 
-// maps for use with various classes
-#ifdef HAVE_BOOST_TR1_UNORDERED_MAP_HPP
-#   include <boost/tr1/unordered_map.hpp>
-    template <class Key, class T>
-    class GenericMap : public std::tr1::unordered_map<Key,T> { };
-    template <class T>
-    class StringMap : public std::tr1::unordered_map<std::string,T> { };
-    template <class T>
-    class KyteaStringMap : public std::tr1::unordered_map<kytea::KyteaString,T,kytea::KyteaStringHash> { };
-#elif HAVE_TR1_UNORDERED_MAP
-#if _MSC_VER >=1600
-#   include <unordered_map>
-#else
-#   include <tr1/unordered_map>
-#endif
-    template <class Key, class T>
-    class GenericMap : public std::tr1::unordered_map<Key,T> { };
-    template <class T>
-    class StringMap : public std::tr1::unordered_map<std::string,T> { };
-    template <class T>
-    class KyteaStringMap : public std::tr1::unordered_map<kytea::KyteaString,T,kytea::KyteaStringHash> { };
-#elif HAVE_EXT_HASH_MAP
-#   include <ext/hash_map>
-    namespace __gnu_cxx {
-    template <>
-    struct hash<std::string> {
-        size_t operator() (const std::string& x) const { return hash<const char*>()(x.c_str()); }
-    };
-    }
-    template <class Key, class T>
-    class GenericMap : public __gnu_cxx::hash_map<Key,T> { };
-    template <class T>
-    class StringMap : public __gnu_cxx::hash_map<std::string,T> { };
-    template <class T>
-    class KyteaStringMap : public __gnu_cxx::hash_map<kytea::KyteaString,T,kytea::KyteaStringHash> { };
-#else
-#   include <map>
-    template <class Key, class T>
-    class GenericMap : public std::map<Key,T> { };
-    template <class T>
-    class StringMap : public std::map<std::string,T> { };
-    template <class T>
-    class KyteaStringMap : public std::map<kytea::KyteaString,T> { };
-#endif
+template <class Key, class T>
+class GenericMap : public std::unordered_map<Key,T> { };
+template <class T>
+class StringMap : public std::unordered_map<std::string,T> { };
+template <class T>
+class KyteaStringMap : public std::unordered_map<kytea::KyteaString,T,kytea::KyteaStringHash> { };
 
 namespace kytea  {
 

--- a/src/lib/string-util.cpp
+++ b/src/lib/string-util.cpp
@@ -270,12 +270,12 @@ KyteaChar StringUtilEuc::mapChar(const string & str, bool add) {
 
 string StringUtilEuc::showChar(KyteaChar c) const {
     if(c < 0x8E) {
-        char arr[2] = { c, 0 };
+        char arr[2] = { static_cast<char>(c), 0 };
         string ret(arr);
         return ret;
     }
     else {
-        char arr[3] = { euc1(c), euc2(c), 0 }; 
+        char arr[3] = { static_cast<char>(euc1(c)), static_cast<char>(euc2(c)), 0 };
         string ret(arr);
         return ret;
     }
@@ -380,12 +380,12 @@ KyteaChar StringUtilSjis::mapChar(const string & str, bool add) {
 
 string StringUtilSjis::showChar(KyteaChar c) const {
     if(c < 0xFF) {
-        char arr[2] = { c, 0 };
+        char arr[2] = { static_cast<char>(c), 0 };
         string ret(arr);
         return ret;
     }
     else {
-        char arr[3] = { sjis1(c), sjis2(c), 0 }; 
+        char arr[3] = { static_cast<char>(sjis1(c)), static_cast<char>(sjis2(c)), 0 };
         string ret(arr);
         return ret;
     }


### PR DESCRIPTION
This migrates the C++ standard version used in KyTea to C++14.

Pros
* No more dependency on Boost or TR1 unordered_map.
* Be able to use smart pointers (e.g., `std::unique_ptr`) for RAII.
* Can take advantage of move semantics introduced in C++11

Cons
* Breaks the ABI of the shard library. Not sure how many users depend on the library, though.