### PR TITLE
Fix memory leaks reported by LeakSanitizer

### DIFF
--- a/src/test/test-corpusio-euc.h
+++ b/src/test/test-corpusio-euc.h
@@ -123,6 +123,7 @@ public:
         outfcio.setUnkTag("/UNK");
         outfcio.writeSentence(sent);
         string act = outstr.str();
+        delete sent;
         if(exp != act) {
             cerr << "exp: "<<exp<<endl<<"act: "<<act<<endl;
             return 0;

--- a/src/test/test-corpusio-sjis.h
+++ b/src/test/test-corpusio-sjis.h
@@ -123,6 +123,7 @@ public:
         outfcio.setUnkTag("/UNK");
         outfcio.writeSentence(sent);
         string act = outstr.str();
+        delete sent;
         if(exp != act) {
             cerr << "exp: "<<exp<<endl<<"act: "<<act<<endl;
             return 0;

--- a/src/test/test-corpusio.h
+++ b/src/test/test-corpusio.h
@@ -56,7 +56,9 @@ public:
         KyteaSentence * sent = io.readSentence();
         // Make the correct words
         KyteaString::Tokens toks = util->mapString("これ は 学習 データ で す 。").tokenize(util->mapString(" "));
-        return checkWordSeg(*sent,toks,util);
+        const int ret = checkWordSeg(*sent,toks,util);
+        delete sent;
+        return ret;
     }
 
     int testRawReadSlash() {
@@ -66,7 +68,9 @@ public:
         KyteaSentence * sent = io.readSentence();
         // Make the correct words
         KyteaString exp = util->mapString("右/左");
-        return exp == sent->surface;
+        const int ret = exp == sent->surface;
+        delete sent;
+        return ret;
     }
 
     int testPartEmptyTag() {
@@ -165,6 +169,7 @@ public:
         outfcio.setUnkTag("/UNK");
         outfcio.writeSentence(sent);
         string act = outstr.str();
+        delete sent;
         if(exp != act) {
             cerr << "exp: "<<exp<<endl<<"act: "<<act<<endl;
             return 0;


### PR DESCRIPTION
This fixes memory leaks in the test program, `test-kytea`.
When I compiled the test program with [ASan](https://clang.llvm.org/docs/AddressSanitizer.html) + [UBSan](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html), [LeakSanitizer](https://clang.llvm.org/docs/LeakSanitizer.html) found a bunch of leaks in the test program.
The cause is that allocated objects by readSentence in derived classes of CorpusIO class are not deleted. The class of issues can be eliminated by using `std::unique_ptr` if KyTea migrates to C++11 or newer standard.

#### Reproducing Steps

```
$ CXXFLAGS="-std=c++14 -g -O0 -fno-omit-frame-pointer -fsanitize=address,undefined" LDFLAGS="-static" ./configure && make -j & make check
````

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/neubig/kytea/30)
<!-- Reviewable:end -->
