### PR TITLE
Use enum for corpus formats

### DIFF
--- a/src/include/Makefile.am
+++ b/src/include/Makefile.am
@@ -1,5 +1,6 @@
 nobase_include_HEADERS = kytea/config.h \
 	kytea/corpus-io.h \
+	kytea/corpus-io-format.h \
 	kytea/corpus-io-eda.h \
 	kytea/corpus-io-full.h \
 	kytea/corpus-io-part.h \

--- a/src/include/kytea/corpus-io-format.h
+++ b/src/include/kytea/corpus-io-format.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020, KyTea Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef KYTEA_CORPUS_IO_FORMAT_H__
+#define KYTEA_CORPUS_IO_FORMAT_H__
+
+namespace kytea {
+
+enum CorpusFormat {
+    CORP_FORMAT_RAW,
+    CORP_FORMAT_FULL,
+    CORP_FORMAT_PART,
+    CORP_FORMAT_PROB,
+    CORP_FORMAT_TOK,
+    CORP_FORMAT_DEFAULT,
+    CORP_FORMAT_EDA,
+    CORP_FORMAT_TAGS,
+};
+
+} // namespace kytea
+
+#endif // KYTEA_CORPUS_IO_FORMAT_H__

--- a/src/include/kytea/corpus-io.h
+++ b/src/include/kytea/corpus-io.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2009, KyTea Development Team
+* Copyright 2009-2020, KyTea Development Team
 * 
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -15,24 +15,11 @@
 */
 
 #ifndef CORPUS_IO_H__ 
-#define CORPUS_IO_H__ 
+#define CORPUS_IO_H__
 
-namespace kytea {
-class CorpusIO;
-const static char CORP_FORMAT_RAW  = 0;
-const static char CORP_FORMAT_FULL = 1;
-const static char CORP_FORMAT_PART = 2;
-const static char CORP_FORMAT_PROB = 3;
-const static char CORP_FORMAT_TOK = 4;
-const static char CORP_FORMAT_DEFAULT = 5;
-const static char CORP_FORMAT_EDA = 6;
-const static char CORP_FORMAT_TAGS = 7;
-}
-
+#include <kytea/corpus-io-format.h>
 #include <kytea/general-io.h>
 #include <vector>
-// #include <kytea/kytea-struct.h>
-// #include <kytea/kytea-config.h>
 
 namespace kytea {
 
@@ -51,8 +38,6 @@ protected:
 
 public:
 
-    typedef char Format;
-
     CorpusIO(StringUtil * util) : GeneralIO(util), unkTag_(), numTags_(0), doTag_() { }
     CorpusIO(StringUtil * util, const char* file, bool out) : GeneralIO(util,file,out,false), numTags_(0), doTag_() { } 
     CorpusIO(StringUtil * util, std::iostream & str, bool out) : GeneralIO(util,str,out,false), numTags_(0), doTag_() { }
@@ -68,8 +53,8 @@ public:
     virtual ~CorpusIO() { }
 
     // create an appropriate parser based on the type
-    static CorpusIO* createIO(const char* file, Format form, const KyteaConfig & conf, bool output, StringUtil* util);
-    static CorpusIO* createIO(std::iostream & str, Format form, const KyteaConfig & conf, bool output, StringUtil* util);
+    static CorpusIO* createIO(const char* file, CorpusFormat form, const KyteaConfig & conf, bool output, StringUtil* util);
+    static CorpusIO* createIO(std::iostream & str, CorpusFormat form, const KyteaConfig & conf, bool output, StringUtil* util);
 
     virtual KyteaSentence * readSentence() = 0;
     virtual void writeSentence(const KyteaSentence * sent, double conf = 0.0) = 0;

--- a/src/include/kytea/kytea-config.h
+++ b/src/include/kytea/kytea-config.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2009, KyTea Development Team
+* Copyright 2009-2020, KyTea Development Team
 * 
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ class KyteaConfig;
 
 #include <string>
 #include <vector>
+#include <kytea/corpus-io-format.h>
 
 namespace kytea {
 
@@ -31,9 +32,6 @@ class StringUtil;
 class KyteaConfig {
 
 private:
-
-    // must be the same as CorpusIO::Format, not used directly because of cross-dependencies
-    typedef char CorpForm;
     bool onTraining_;
 
     unsigned debug_;            // the debugging level
@@ -45,7 +43,7 @@ private:
     StringUtil * util_;         // a std::string utility to hold the encoding, etc
 
     std::vector<std::string> corpora_;    // corpora to read for training
-    std::vector<CorpForm> corpusFormats_; // the annotation of each corpus
+    std::vector<CorpusFormat> corpusFormats_; // the annotation of each corpus
     
     std::vector<std::string> dicts_;      // dictionaries to read
 
@@ -55,7 +53,7 @@ private:
     char modelForm_;             // model format (ModelIO::Format)
 
     std::string input_, output_;     // the file to input/output
-    CorpForm inputForm_, outputForm_; // the format/file to input/output to (default: stdout, full)
+    CorpusFormat inputForm_, outputForm_; // the format/file to input/output to (default: stdout, full)
 
     std::string featIn_, featOut_;
     std::ostream* featStr_;
@@ -94,7 +92,7 @@ private:
     std::vector<std::string> args_;
 
     // set the type of the input corpus
-    void setIOFormat(const char* str, CorpForm & cf);
+    void setIOFormat(const char* str, CorpusFormat & cf);
     
     // formatting tags
     std::string wordBound_, tagBound_, elemBound_, unkBound_, noBound_, hasBound_, skipBound_, escape_;
@@ -116,7 +114,7 @@ public:
     KyteaConfig();
     KyteaConfig(const KyteaConfig & rhs);
     ~KyteaConfig();
-    void addCorpus(const std::string & corp, CorpForm format);
+    void addCorpus(const std::string & corp, CorpusFormat format);
     void addDictionary(const std::string & corp);
     void addSubwordDict(const std::string & corp);
 
@@ -137,7 +135,7 @@ public:
 
     // getters
     const std::vector<std::string> & getCorpusFiles() const { return corpora_; }
-    const std::vector<CorpForm> & getCorpusFormats() const { return corpusFormats_; }
+    const std::vector<CorpusFormat> & getCorpusFormats() const { return corpusFormats_; }
     const std::vector<std::string> & getDictionaryFiles() const { return dicts_; }
     const std::vector<std::string> & getSubwordDictFiles() const { return subwordDicts_; }
     const std::string & getModelFile();
@@ -145,8 +143,8 @@ public:
     const unsigned getDebug() const { return debug_; }
     StringUtil * getStringUtil() { return util_; }
     const StringUtil * getStringUtil() const { return util_; }
-    const CorpForm getInputFormat() const { return inputForm_; }
-    const CorpForm getOutputFormat() const { return outputForm_; }
+    const CorpusFormat getInputFormat() const { return inputForm_; }
+    const CorpusFormat getOutputFormat() const { return outputForm_; }
     const std::string & getFeatureIn() const { return featIn_; }
     const std::string & getFeatureOut() const { return featOut_; }
     const bool getWriteFeatures() const { return featOut_.length() > 0; }
@@ -216,7 +214,7 @@ public:
         if(i >= (int)doTag_.size()) doTag_.resize(i+1,true); 
         doTag_[i] = v;
     } 
-    void setInputFormat(CorpForm v) { inputForm_ = v; }
+    void setInputFormat(CorpusFormat v) { inputForm_ = v; }
     void setWordBound(const char* v) { wordBound_ = v; } 
     void setTagBound(const char* v) { tagBound_ = v; } 
     void setElemBound(const char* v) { elemBound_ = v; } 

--- a/src/lib/corpus-io.cpp
+++ b/src/lib/corpus-io.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright 2009, KyTea Development Team
+* Copyright 2009-2020, KyTea Development Team
 * 
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -33,34 +33,71 @@
 using namespace kytea;
 using namespace std;
 
-CorpusIO * CorpusIO::createIO(const char* file, Format form, const KyteaConfig & conf, bool output, StringUtil* util) {
-    if(form == CORP_FORMAT_FULL)      { return new FullCorpusIO(util,file,output,conf.getWordBound(),conf.getTagBound(),conf.getElemBound(),conf.getEscape()); }
-    else if(form == CORP_FORMAT_TAGS)      { 
-        FullCorpusIO * io = new FullCorpusIO(util,file,output,conf.getWordBound(),conf.getTagBound(),conf.getElemBound(),conf.getEscape());
-        io->setPrintWords(false);
-        return io;
+CorpusIO * CorpusIO::createIO(const char* file, CorpusFormat form, const KyteaConfig & conf, bool output, StringUtil* util) {
+    switch (form) {
+        case CORP_FORMAT_FULL:
+            return new FullCorpusIO(util, file, output, conf.getWordBound(),
+                                    conf.getTagBound(), conf.getElemBound(),
+                                    conf.getEscape());
+        case CORP_FORMAT_TAGS: {
+            FullCorpusIO* io = new FullCorpusIO(
+                util, file, output, conf.getWordBound(), conf.getTagBound(),
+                conf.getElemBound(), conf.getEscape());
+            io->setPrintWords(false);
+            return io;
+        }
+        case CORP_FORMAT_TOK:
+            return new TokenizedCorpusIO(util, file, output,
+                                         conf.getWordBound());
+        case CORP_FORMAT_PART:
+            return new PartCorpusIO(util, file, output, conf.getUnkBound(),
+                                    conf.getSkipBound(), conf.getNoBound(),
+                                    conf.getHasBound(), conf.getTagBound(),
+                                    conf.getElemBound(), conf.getEscape());
+        case CORP_FORMAT_PROB:
+            return new ProbCorpusIO(util, file, output, conf.getWordBound(),
+                                    conf.getTagBound(), conf.getElemBound(),
+                                    conf.getEscape());
+        case CORP_FORMAT_RAW:
+            return new RawCorpusIO(util, file, output);
+        case CORP_FORMAT_EDA:
+            return new EdaCorpusIO(util, file, output);
+        default:
+            THROW_ERROR("Illegal Output Format");
     }
-    else if(form == CORP_FORMAT_TOK)      { return new TokenizedCorpusIO(util,file,output,conf.getWordBound()); }
-    else if(form == CORP_FORMAT_PART) { return new PartCorpusIO(util,file,output,conf.getUnkBound(),conf.getSkipBound(),conf.getNoBound(),conf.getHasBound(),conf.getTagBound(),conf.getElemBound(),conf.getEscape()); }
-    else if(form == CORP_FORMAT_PROB) { return new ProbCorpusIO(util,file,output,conf.getWordBound(),conf.getTagBound(),conf.getElemBound(),conf.getEscape()); }
-    else if(form == CORP_FORMAT_RAW)  { return new RawCorpusIO(util,file,output);  }
-    else if(form == CORP_FORMAT_EDA)  { return new EdaCorpusIO(util,file,output);  }
-    else
-        THROW_ERROR("Illegal Output Format");
 }
 
-CorpusIO * CorpusIO::createIO(iostream & file, Format form, const KyteaConfig & conf, bool output, StringUtil* util) {
-    if(form == CORP_FORMAT_FULL)      { return new FullCorpusIO(util,file,output,conf.getWordBound(),conf.getTagBound(),conf.getElemBound(),conf.getEscape()); }
-    else if(form == CORP_FORMAT_TAGS)      { 
-        FullCorpusIO * io = new FullCorpusIO(util,file,output,conf.getWordBound(),conf.getTagBound(),conf.getElemBound(),conf.getEscape());
-        io->setPrintWords(false);
-        return io;
+CorpusIO * CorpusIO::createIO(iostream & file, CorpusFormat form, const KyteaConfig & conf, bool output, StringUtil* util) {
+    switch (form) {
+        case CORP_FORMAT_FULL:
+            new FullCorpusIO(util, file, output, conf.getWordBound(),
+                             conf.getTagBound(), conf.getElemBound(),
+                             conf.getEscape());
+        case CORP_FORMAT_TAGS: {
+            FullCorpusIO* io = new FullCorpusIO(
+                util, file, output, conf.getWordBound(), conf.getTagBound(),
+                conf.getElemBound(), conf.getEscape());
+            io->setPrintWords(false);
+            return io;
+        }
+        case CORP_FORMAT_TOK:
+            return new TokenizedCorpusIO(util, file, output,
+                                         conf.getWordBound());
+        case CORP_FORMAT_PART:
+            return new PartCorpusIO(util, file, output, conf.getUnkBound(),
+                                    conf.getSkipBound(), conf.getNoBound(),
+                                    conf.getHasBound(), conf.getTagBound(),
+                                    conf.getElemBound(), conf.getEscape());
+
+        case CORP_FORMAT_PROB:
+            return new ProbCorpusIO(util, file, output, conf.getWordBound(),
+                                    conf.getTagBound(), conf.getElemBound(),
+                                    conf.getEscape());
+        case CORP_FORMAT_RAW:
+            return new RawCorpusIO(util, file, output);
+        case CORP_FORMAT_EDA:
+            return new EdaCorpusIO(util, file, output);
+        default:
+            THROW_ERROR("Illegal Output Format");
     }
-    else if(form == CORP_FORMAT_TOK)      { return new TokenizedCorpusIO(util,file,output,conf.getWordBound()); }
-    else if(form == CORP_FORMAT_PART) { return new PartCorpusIO(util,file,output,conf.getUnkBound(),conf.getSkipBound(),conf.getNoBound(),conf.getHasBound(),conf.getTagBound(),conf.getElemBound(),conf.getEscape()); }
-    else if(form == CORP_FORMAT_PROB) { return new ProbCorpusIO(util,file,output,conf.getWordBound(),conf.getTagBound(),conf.getElemBound(),conf.getEscape()); }
-    else if(form == CORP_FORMAT_RAW)  { return new RawCorpusIO(util,file,output);  }
-    else if(form == CORP_FORMAT_EDA)  { return new EdaCorpusIO(util,file,output);  }
-    else 
-        THROW_ERROR("Illegal Output Format");
 }

--- a/src/lib/kytea-config.cpp
+++ b/src/lib/kytea-config.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright 2009, KyTea Development Team
+* Copyright 2009-2020, KyTea Development Team
 * 
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ using namespace kytea;
 using namespace std;
 
 // set the type of the input corpus
-void KyteaConfig::setIOFormat(const char* str, CorpForm & cf) {
+void KyteaConfig::setIOFormat(const char* str, CorpusFormat & cf) {
     if(!strcmp(str, "full"))      { cf = CORP_FORMAT_FULL; }
     else if(!strcmp(str, "tags"))  { cf = CORP_FORMAT_TAGS; }
     else if(!strcmp(str, "tok"))  { cf = CORP_FORMAT_TOK; }
@@ -333,7 +333,7 @@ KyteaConfig::~KyteaConfig() {
         delete util_;
 }
 
-void KyteaConfig::addCorpus(const std::string & corp, CorpForm format) {
+void KyteaConfig::addCorpus(const std::string & corp, CorpusFormat format) {
     corpora_.push_back(corp);
     corpusFormats_.push_back(format);
 }

--- a/src/lib/kytea.cpp
+++ b/src/lib/kytea.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright 2009, KyTea Development Team
+* Copyright 2009-2020, KyTea Development Team
 * 
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -136,7 +136,7 @@ void Kytea::buildVocabulary() {
     
     // scan the corpora
     vector<string> corpora = config_->getCorpusFiles();
-    vector<CorpusIO::Format> corpForm = config_->getCorpusFormats();
+    vector<CorpusFormat> corpForm = config_->getCorpusFormats();
     int maxTag = config_->getNumTags();
     for(unsigned i = 0; i < corpora.size(); i++) {
         if(config_->getDebug() > 0)


### PR DESCRIPTION
This simplifies the type to represent corpus formats using enum.
Currently, `KyteaConfig::CorpForm` and `CorpusIO::Format` are used for the formats, which is unnecessarily complicated. This can be simplified by defining the enum constatnts at a different header, and by including the header.
By representing the type as enum, the compiler such as clang can find missing enum case in switch statement at compile time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/neubig/kytea/31)
<!-- Reviewable:end -->
