### PR TITLE
Explicitly annotate overrides of virtual functions

### DIFF
--- a/src/include/kytea/corpus-io-eda.h
+++ b/src/include/kytea/corpus-io-eda.h
@@ -13,8 +13,8 @@ public:
     EdaCorpusIO(StringUtil * util, const char* file, bool out);
     EdaCorpusIO(StringUtil * util, std::iostream & str, bool out);
     
-    KyteaSentence * readSentence();
-    void writeSentence(const KyteaSentence * sent, double conf = 0.0);
+    KyteaSentence * readSentence() override;
+    void writeSentence(const KyteaSentence * sent, double conf = 0.0) override;
 
 protected:
     // The ID of the last sentence printed

--- a/src/include/kytea/corpus-io-full.h
+++ b/src/include/kytea/corpus-io-full.h
@@ -20,8 +20,8 @@ public:
     FullCorpusIO(StringUtil * util, const char* file, bool out, const char* wordBound = " ", const char* tagBound = "/", const char* elemBound = "&", const char* escape = "\\");
     FullCorpusIO(StringUtil * util, std::iostream & str, bool out, const char* wordBound = " ", const char* tagBound = "/", const char* elemBound = "&", const char* escape = "\\");
     
-    KyteaSentence * readSentence();
-    void writeSentence(const KyteaSentence * sent, double conf = 0.0);
+    KyteaSentence * readSentence() override;
+    void writeSentence(const KyteaSentence * sent, double conf = 0.0) override;
     void setPrintWords(bool printWords) { printWords_ = printWords; }
 
 };

--- a/src/include/kytea/corpus-io-part.h
+++ b/src/include/kytea/corpus-io-part.h
@@ -27,8 +27,8 @@ public:
     PartCorpusIO(StringUtil * util, std::iostream & str, bool out, const char* unkBound = " ", const char* skipBound = "?", const char* noBound = "-", const char* hasBound = "|", const char* tagBound = "/", const char* elemBound = "&", const char* escape = "\\");
     PartCorpusIO(StringUtil * util, const char* file, bool out, const char* unkBound = " ", const char* skipBound = "?", const char* noBound = "-", const char* hasBound = "|", const char* tagBound = "/", const char* elemBound = "&", const char* escape = "\\");
     
-    KyteaSentence * readSentence();
-    void writeSentence(const KyteaSentence * sent, double conf = 0.0);
+    KyteaSentence * readSentence() override;
+    void writeSentence(const KyteaSentence * sent, double conf = 0.0) override;
 
 };
 

--- a/src/include/kytea/corpus-io-prob.h
+++ b/src/include/kytea/corpus-io-prob.h
@@ -13,8 +13,8 @@ public:
     ProbCorpusIO(StringUtil * util, const char* file, bool out, const char* wordBound = " ", const char* tagBound = "/", const char* elemBound = "&", const char* escape = "\\") : FullCorpusIO(util,file,out,wordBound,tagBound,elemBound,escape) { allTags_ = true; } 
     ProbCorpusIO(StringUtil * util, std::iostream & str, bool out, const char* wordBound = " ", const char* tagBound = "/", const char* elemBound = "&", const char* escape = "\\") : FullCorpusIO(util,str,out,wordBound,tagBound,elemBound,escape) { allTags_ = true; }
 
-    KyteaSentence * readSentence();
-    void writeSentence(const KyteaSentence * sent, double conf = 0.0);
+    KyteaSentence * readSentence() override;
+    void writeSentence(const KyteaSentence * sent, double conf = 0.0) override;
 
 };
 

--- a/src/include/kytea/corpus-io-raw.h
+++ b/src/include/kytea/corpus-io-raw.h
@@ -13,8 +13,8 @@ public:
     RawCorpusIO(StringUtil * util, const char* file, bool out) : CorpusIO(util,file,out) { } 
     RawCorpusIO(StringUtil * util, std::iostream & str, bool out) : CorpusIO(util,str,out) { }
 
-    KyteaSentence * readSentence();
-    void writeSentence(const KyteaSentence * sent, double conf = 0.0);
+    KyteaSentence * readSentence() override;
+    void writeSentence(const KyteaSentence * sent, double conf = 0.0) override;
 
 };
 

--- a/src/include/kytea/corpus-io-tokenized.h
+++ b/src/include/kytea/corpus-io-tokenized.h
@@ -20,8 +20,8 @@ public:
     TokenizedCorpusIO(StringUtil * util, const char* file, bool out, const char* wordBound = " ");
     TokenizedCorpusIO(StringUtil * util, std::iostream & str, bool out, const char* wordBound = " ");
     
-    KyteaSentence * readSentence();
-    void writeSentence(const KyteaSentence * sent, double conf = 0.0);
+    KyteaSentence * readSentence() override;
+    void writeSentence(const KyteaSentence * sent, double conf = 0.0) override;
 
 };
 

--- a/src/include/kytea/dictionary.h
+++ b/src/include/kytea/dictionary.h
@@ -65,7 +65,7 @@ public:
     ModelTagEntry(const KyteaString & str) : TagEntry(str) { }
     ~ModelTagEntry();
 
-    void setNumTags(int i) {
+    void setNumTags(int i) override {
         TagEntry::setNumTags(i);
         tagMods.resize(i,0);
     }
@@ -81,7 +81,7 @@ public:
     
     double incrementProb(const KyteaString & str, int lev);
 
-    void setNumTags(int i) {
+    void setNumTags(int i) override {
         TagEntry::setNumTags(i);
         probs.resize(i);
     }

--- a/src/include/kytea/model-io-binary.h
+++ b/src/include/kytea/model-io-binary.h
@@ -16,15 +16,15 @@ public:
 
     // output functions
 
-    void writeConfig(const KyteaConfig & conf);
-    void writeModel(const KyteaModel * mod);
-    void writeWordList(const std::vector<KyteaString> & list);
-    void writeModelDictionary(const Dictionary<ModelTagEntry> * dict) { writeDictionary(dict); }
-    void writeProbDictionary(const Dictionary<ProbTagEntry> * dict) { writeDictionary(dict); }
-    void writeVectorDictionary(const Dictionary<FeatVec > * dict) { writeDictionary(dict); }
-    void writeLM(const KyteaLM * mod);
-    void writeFeatVec(const FeatVec * vec);
-    void writeFeatureLookup(const FeatureLookup * featLookup);
+    void writeConfig(const KyteaConfig & conf) override;
+    void writeModel(const KyteaModel * mod) override;
+    void writeWordList(const std::vector<KyteaString> & list) override;
+    void writeModelDictionary(const Dictionary<ModelTagEntry> * dict) override { writeDictionary(dict); }
+    void writeProbDictionary(const Dictionary<ProbTagEntry> * dict) override { writeDictionary(dict); }
+    void writeVectorDictionary(const Dictionary<FeatVec > * dict) override { writeDictionary(dict); }
+    void writeLM(const KyteaLM * mod) override;
+    void writeFeatVec(const FeatVec * vec) override;
+    void writeFeatureLookup(const FeatureLookup * featLookup) override;
 
     template <class Entry>
     void writeEntry(const Entry * entry);
@@ -66,15 +66,15 @@ public:
 
 
     // input functions
-    void readConfig(KyteaConfig & conf);
-    KyteaModel * readModel();
-    std::vector<KyteaString> readWordList();
-    Dictionary<ModelTagEntry> * readModelDictionary() { return readDictionary<ModelTagEntry>(); }
-    Dictionary<ProbTagEntry> * readProbDictionary()  { return readDictionary<ProbTagEntry>(); }
-    Dictionary<FeatVec > * readVectorDictionary()  { return readDictionary<FeatVec >(); }
-    KyteaLM * readLM();
-    FeatVec * readFeatVec();
-    FeatureLookup * readFeatureLookup();
+    void readConfig(KyteaConfig & conf) override;
+    KyteaModel * readModel() override;
+    std::vector<KyteaString> readWordList() override;
+    Dictionary<ModelTagEntry> * readModelDictionary() override { return readDictionary<ModelTagEntry>(); }
+    Dictionary<ProbTagEntry> * readProbDictionary() override { return readDictionary<ProbTagEntry>(); }
+    Dictionary<FeatVec > * readVectorDictionary() override { return readDictionary<FeatVec >(); }
+    KyteaLM * readLM() override;
+    FeatVec * readFeatVec() override;
+    FeatureLookup * readFeatureLookup() override;
 
     template <class Entry>
     Entry * readEntry();

--- a/src/include/kytea/model-io-text.h
+++ b/src/include/kytea/model-io-text.h
@@ -18,15 +18,15 @@ public:
 
     // writing functions
 
-    void writeConfig(const KyteaConfig & conf);
-    void writeModel(const KyteaModel * mod);
-    void writeWordList(const std::vector<KyteaString> & list);
-    void writeModelDictionary(const Dictionary<ModelTagEntry> * dict) { writeDictionary(dict); }
-    void writeProbDictionary(const Dictionary<ProbTagEntry> * dict) { writeDictionary(dict); }
-    void writeVectorDictionary(const Dictionary<FeatVec > * dict) { writeDictionary(dict); }
-    void writeLM(const KyteaLM * mod);
-    void writeFeatVec(const FeatVec * vec);
-    void writeFeatureLookup(const FeatureLookup * featLookup);
+    void writeConfig(const KyteaConfig & conf) override;
+    void writeModel(const KyteaModel * mod) override;
+    void writeWordList(const std::vector<KyteaString> & list) override;
+    void writeModelDictionary(const Dictionary<ModelTagEntry> * dict) override { writeDictionary(dict); }
+    void writeProbDictionary(const Dictionary<ProbTagEntry> * dict) override { writeDictionary(dict); }
+    void writeVectorDictionary(const Dictionary<FeatVec > * dict) override { writeDictionary(dict); }
+    void writeLM(const KyteaLM * mod) override;
+    void writeFeatVec(const FeatVec * vec) override;
+    void writeFeatureLookup(const FeatureLookup * featLookup) override;
 
     template <class Entry>
     void writeEntry(const Entry * entry);
@@ -66,15 +66,15 @@ public:
     static CorpusIO* createIO(const char* file, Format form, bool output, StringUtil* util);
     static CorpusIO* createIO(std::iostream & str, Format form, bool output, StringUtil* util);
 
-    void readConfig(KyteaConfig & conf);
-    KyteaModel * readModel();
-    std::vector<KyteaString> readWordList();
-    Dictionary<ModelTagEntry> * readModelDictionary() { return readDictionary<ModelTagEntry>(); }
-    Dictionary<ProbTagEntry> * readProbDictionary()  { return readDictionary<ProbTagEntry>(); }
-    Dictionary<FeatVec > * readVectorDictionary()  { return readDictionary<FeatVec >(); }
-    KyteaLM * readLM();
-    FeatVec * readFeatVec();
-    FeatureLookup * readFeatureLookup();
+    void readConfig(KyteaConfig & conf) override;
+    KyteaModel * readModel() override;
+    std::vector<KyteaString> readWordList() override;
+    Dictionary<ModelTagEntry> * readModelDictionary() override { return readDictionary<ModelTagEntry>(); }
+    Dictionary<ProbTagEntry> * readProbDictionary() override { return readDictionary<ProbTagEntry>(); }
+    Dictionary<FeatVec > * readVectorDictionary() override { return readDictionary<FeatVec >(); }
+    KyteaLM * readLM() override;
+    FeatVec * readFeatVec() override;
+    FeatureLookup * readFeatureLookup() override;
 
     template <class Entry>
     Entry * readEntry();

--- a/src/include/kytea/string-util.h
+++ b/src/include/kytea/string-util.h
@@ -141,27 +141,27 @@ public:
     ~StringUtilUtf8() { }
     
     // map a std::string to a character
-    KyteaChar mapChar(const std::string & str, bool add = true);
-    std::string showChar(KyteaChar c) const;
+    KyteaChar mapChar(const std::string & str, bool add = true) override;
+    std::string showChar(KyteaChar c) const override;
 
-    CharType findType(KyteaChar c) const;
+    CharType findType(KyteaChar c) const override;
 
-    GenericMap<KyteaChar,KyteaChar> * getNormMap();
+    GenericMap<KyteaChar,KyteaChar> * getNormMap() override;
 
     bool badu(char val) const { return ((val ^ maskl1) & maskl2); }
-    KyteaString mapString(const std::string & str);
+    KyteaString mapString(const std::string & str) override;
 
     // find the type of a unicode character
-    CharType findType(const std::string & str);
+    CharType findType(const std::string & str) override;
 
-    Encoding getEncoding() const { return ENCODING_UTF8; }
-    const char* getEncodingString() const { return "utf8"; }
+    Encoding getEncoding() const override { return ENCODING_UTF8; }
+    const char* getEncodingString() const override { return "utf8"; }
 
     const std::vector<std::string> & getCharNames() const { return charNames_; }
 
     // transform to or from a character std::string
-    void unserialize(const std::string & str);
-    std::string serialize() const;
+    void unserialize(const std::string & str) override;
+    std::string serialize() const override;
 
 };
 
@@ -175,25 +175,25 @@ public:
     StringUtilEuc() { };
     ~StringUtilEuc() { }
 
-    KyteaChar mapChar(const std::string & str, bool add = true);
-    std::string showChar(KyteaChar c) const;
+    KyteaChar mapChar(const std::string & str, bool add = true) override;
+    std::string showChar(KyteaChar c) const override;
     
-    GenericMap<KyteaChar,KyteaChar> * getNormMap();
+    GenericMap<KyteaChar,KyteaChar> * getNormMap() override;
 
     // map an unparsed std::string to a KyteaString
-    KyteaString mapString(const std::string & str);
+    KyteaString mapString(const std::string & str) override;
 
     // get the type of a character
-    CharType findType(const std::string & str);
-    CharType findType(KyteaChar c) const;
+    CharType findType(const std::string & str) override;
+    CharType findType(KyteaChar c) const override;
 
     // return the encoding provided by this util
-    Encoding getEncoding() const;
-    const char* getEncodingString() const;
+    Encoding getEncoding() const override;
+    const char* getEncodingString() const override;
     
     // transform to or from a character std::string
-    void unserialize(const std::string & str);
-    std::string serialize() const;
+    void unserialize(const std::string & str) override;
+    std::string serialize() const override;
 
 };
 
@@ -207,25 +207,25 @@ public:
     StringUtilSjis() { };
     ~StringUtilSjis() { }
 
-    KyteaChar mapChar(const std::string & str, bool add = true);
-    GenericMap<KyteaChar,KyteaChar> * getNormMap();
+    KyteaChar mapChar(const std::string & str, bool add = true) override;
+    GenericMap<KyteaChar,KyteaChar> * getNormMap() override;
 
-    std::string showChar(KyteaChar c) const;
+    std::string showChar(KyteaChar c) const override;
     
     // map an unparsed std::string to a KyteaString
-    KyteaString mapString(const std::string & str);
+    KyteaString mapString(const std::string & str) override;
 
     // get the type of a character
-    CharType findType(const std::string & str);
-    CharType findType(KyteaChar c) const;
+    CharType findType(const std::string & str) override;
+    CharType findType(KyteaChar c) const override;
 
     // return the encoding provided by this util
-    Encoding getEncoding() const;
-    const char* getEncodingString() const;
+    Encoding getEncoding() const override;
+    const char* getEncodingString() const override;
     
     // transform to or from a character std::string
-    void unserialize(const std::string & str);
-    std::string serialize() const;
+    void unserialize(const std::string & str) override;
+    std::string serialize() const override;
 
 };
 


### PR DESCRIPTION
This annotates override of virtual functions with the following rationale:

>  A function or destructor marked override or final that is not an override of a base class virtual function will not compile, and this helps catch common errors. The specifiers serve as documentation; if no specifier is present, the reader has to check all ancestors of the class in question to determine if the function or destructor is virtual or not.
from https://google.github.io/styleguide/cppguide.html#Inheritance

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/neubig/kytea/33)
<!-- Reviewable:end -->
