### PR TITLE
Use enum for model formats

### DIFF
--- a/src/include/kytea/kytea-config.h
+++ b/src/include/kytea/kytea-config.h
@@ -24,6 +24,7 @@ class KyteaConfig;
 #include <string>
 #include <vector>
 #include <kytea/corpus-io-format.h>
+#include <kytea/model-io-format.h>
 
 namespace kytea {
 
@@ -50,7 +51,7 @@ private:
     std::vector<std::string> subwordDicts_; // subword dictionaries to use for unknown estimation
 
     std::string model_;              // model file to write/read
-    char modelForm_;             // model format (ModelIO::Format)
+    ModelFormat modelForm_;          // model format
 
     std::string input_, output_;     // the file to input/output
     CorpusFormat inputForm_, outputForm_; // the format/file to input/output to (default: stdout, full)
@@ -139,7 +140,7 @@ public:
     const std::vector<std::string> & getDictionaryFiles() const { return dicts_; }
     const std::vector<std::string> & getSubwordDictFiles() const { return subwordDicts_; }
     const std::string & getModelFile();
-    const char getModelFormat() const { return modelForm_; }
+    ModelFormat getModelFormat() const { return modelForm_; }
     const unsigned getDebug() const { return debug_; }
     StringUtil * getStringUtil() { return util_; }
     const StringUtil * getStringUtil() const { return util_; }
@@ -189,7 +190,7 @@ public:
     // setters
     void setDebug(unsigned debug) { debug_ = debug; }
     void setModelFile(const char* file) { model_ = file; }
-    void setModelFormat(char mf) { modelForm_ = mf; }
+    void setModelFormat(ModelFormat mf) { modelForm_ = mf; }
     void setEpsilon(double v) { eps_ = v; }
     void setCost(double v) { cost_ = v; }
     void setBias(bool v) { bias_ = (v?1.0f:-1.0f); }

--- a/src/include/kytea/model-io-format.h
+++ b/src/include/kytea/model-io-format.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020, KyTea Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef KYTEA_MODEL_IO_FORMAT_H__
+#define KYTEA_MODEL_IO_FORMAT_H__
+
+namespace kytea {
+
+enum ModelFormat : char {
+    MODEL_FORMAT_BINARY = 'B',
+    MODEL_FORMAT_TEXT = 'T',
+    MODEL_FORMAT_UNKNOWN = 'U',
+};
+
+}  // namespace kytea
+
+#endif // KYTEA_MODEL_IO_FORMAT_H__

--- a/src/include/kytea/model-io-text.h
+++ b/src/include/kytea/model-io-text.h
@@ -63,8 +63,8 @@ public:
     }
 
     // create an appropriate parser based on the type
-    static CorpusIO* createIO(const char* file, Format form, bool output, StringUtil* util);
-    static CorpusIO* createIO(std::iostream & str, Format form, bool output, StringUtil* util);
+    static CorpusIO* createIO(const char* file, ModelFormat form, bool output, StringUtil* util);
+    static CorpusIO* createIO(std::iostream & str, ModelFormat form, bool output, StringUtil* util);
 
     void readConfig(KyteaConfig & conf) override;
     KyteaModel * readModel() override;

--- a/src/include/kytea/model-io.h
+++ b/src/include/kytea/model-io.h
@@ -20,6 +20,7 @@
 #include <kytea/dictionary.h>
 #include <kytea/general-io.h>
 #include <kytea/feature-vector.h>
+#include <kytea/model-io-format.h>
 #include <vector>
 
 #if DISABLE_QUANTIZE
@@ -40,11 +41,6 @@ class ModelIO : public GeneralIO {
 
 public:
 
-    typedef char Format;
-    const static Format FORMAT_BINARY = 'B';
-    const static Format FORMAT_TEXT = 'T';
-    const static Format FORMAT_UNKNOWN = 'U';
-
     int numTags_;
 
 public:
@@ -55,8 +51,8 @@ public:
 
     virtual ~ModelIO() { }
 
-    static ModelIO* createIO(const char* file, Format form, bool output, KyteaConfig & config);
-    static ModelIO* createIO(std::iostream & str, Format form, bool output, KyteaConfig & config);
+    static ModelIO* createIO(const char* file, ModelFormat form, bool output, KyteaConfig & config);
+    static ModelIO* createIO(std::iostream & str, ModelFormat form, bool output, KyteaConfig & config);
 
     virtual void writeConfig(const KyteaConfig & conf) = 0;
     virtual void writeModel(const KyteaModel * mod) = 0;

--- a/src/lib/kytea-config.cpp
+++ b/src/lib/kytea-config.cpp
@@ -183,7 +183,7 @@ unsigned KyteaConfig::parseTrainArg(const char * n, const char * v) {
 
     // output option for training
     else if(!strcmp(n, "-model"))    { ch(n,v); setModelFile(v); }
-    else if(!strcmp(n, "-modtext"))  { setModelFormat('T'); r=0; }
+    else if(!strcmp(n, "-modtext"))  { setModelFormat(MODEL_FORMAT_TEXT); r=0; }
     else if(!strcmp(n, "-featout"))  { ch(n,v); setFeatureOut(v); }
     else if(!strcmp(n, "-feat"))     { ch(n,v); setFeatureIn(v); }
     else if(!strcmp(n, "-numtags"))  { ch(n,v); setNumTags(util_->parseInt(v)); }
@@ -292,7 +292,7 @@ void KyteaConfig::setEncoding(const char* str) {
 
 
 KyteaConfig::KyteaConfig() : onTraining_(true), debug_(0), util_(0), dicts_(), 
-                modelForm_('B'), inputForm_(CORP_FORMAT_DEFAULT),
+                modelForm_(MODEL_FORMAT_BINARY), inputForm_(CORP_FORMAT_DEFAULT),
                 outputForm_(CORP_FORMAT_FULL), featStr_(0),
                 doWS_(true), doTags_(true), doUnk_(true),
                 addFeat_(false), confidence_(0.0), charW_(3), charN_(3), 

--- a/src/lib/kytea.cpp
+++ b/src/lib/kytea.cpp
@@ -846,8 +846,8 @@ void Kytea::readModel(const char* fileName) {
     if(config_->getDebug() > 0)
         cerr << "Reading model from " << fileName;
 
-    
-    ModelIO * modin = ModelIO::createIO(fileName,ModelIO::FORMAT_UNKNOWN, false, *config_);
+    ModelIO* modin =
+        ModelIO::createIO(fileName, MODEL_FORMAT_UNKNOWN, false, *config_);
     util_ = config_->getStringUtil();
 
     modin->readConfig(*config_);

--- a/src/lib/model-io.cpp
+++ b/src/lib/model-io.cpp
@@ -43,8 +43,8 @@ static const char *solver_type_table[]=
 	"L2R_LR", "L2R_L2LOSS_SVC_DUAL", "L2R_L2LOSS_SVC","L2R_L1LOSS_SVC_DUAL","MCSVM_CS","L1R_L2LOSS_SVC","L1R_LR","L2R_LR_DUAL", NULL
 };
 
-ModelIO * ModelIO::createIO(const char* file, Format form, bool output, KyteaConfig & config) {
-    if(output && form == ModelIO::FORMAT_UNKNOWN) {
+ModelIO * ModelIO::createIO(const char* file, ModelFormat form, bool output, KyteaConfig & config) {
+    if(output && form == MODEL_FORMAT_UNKNOWN) {
         THROW_ERROR("A format must be specified for model output");
     } else if(!output) {
         ifstream ifs(file);
@@ -58,24 +58,31 @@ ModelIO * ModelIO::createIO(const char* file, Format form, bool output, KyteaCon
             THROW_ERROR("Badly formed model (header incorrect)");
         if(buff2 != MODEL_IO_VERSION)
             THROW_ERROR("Incompatible model version. Expected " << MODEL_IO_VERSION << ", but found " << buff2 << ".");
-        form = buff3[0];
+        form = static_cast<ModelFormat>(buff3[0]);
         config.setEncoding(buff4.c_str());
         ifs.close();
     }
     StringUtil * util = config.getStringUtil();
-    if(form == ModelIO::FORMAT_TEXT)      { return new TextModelIO(util,file,output); }
-    else if(form == ModelIO::FORMAT_BINARY) { return new BinaryModelIO(util,file,output); }
-    else {
-        THROW_ERROR("Illegal model format");
+    switch (form) {
+        case MODEL_FORMAT_TEXT:
+            return new TextModelIO(util, file, output);
+        case MODEL_FORMAT_BINARY:
+            return new BinaryModelIO(util, file, output);
+        default:
+            THROW_ERROR("Illegal model format");
     }
 }
 
-ModelIO * ModelIO::createIO(iostream & file, Format form, bool output, KyteaConfig & config) {
-    StringUtil * util = config.getStringUtil();
-    if(form == ModelIO::FORMAT_TEXT)      { return new TextModelIO(util,file,output); }
-    else if(form == ModelIO::FORMAT_BINARY) { return new BinaryModelIO(util,file,output); }
-    else {
-        THROW_ERROR("Illegal model format");
+ModelIO* ModelIO::createIO(iostream& file, ModelFormat form, bool output,
+                           KyteaConfig& config) {
+    StringUtil* util = config.getStringUtil();
+    switch (form) {
+        case MODEL_FORMAT_TEXT:
+            return new TextModelIO(util, file, output);
+        case MODEL_FORMAT_BINARY:
+            return new BinaryModelIO(util, file, output);
+        default:
+            THROW_ERROR("Illegal model format");
     }
 }
 

--- a/src/test/test-analysis.h
+++ b/src/test/test-analysis.h
@@ -362,7 +362,7 @@ public:
 
     int testTextIO() {
         // Write the model
-        kytea->getConfig()->setModelFormat(ModelIO::FORMAT_TEXT);
+        kytea->getConfig()->setModelFormat(MODEL_FORMAT_TEXT);
         kytea->writeModel("/tmp/kytea-model.txt");
         // Read the model
         Kytea actKytea;
@@ -374,7 +374,7 @@ public:
 
     int testBinaryIO() {
         // Write the model
-        kytea->getConfig()->setModelFormat(ModelIO::FORMAT_BINARY);
+        kytea->getConfig()->setModelFormat(MODEL_FORMAT_BINARY);
         kytea->writeModel("/tmp/kytea-model.bin");
         // Read the model
         Kytea actKytea;


### PR DESCRIPTION
This uses enum for model formats as #31 did for corpus formats.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/neubig/kytea/35)
<!-- Reviewable:end -->
