### PR TITLE
Use std::unique_ptr for readSentence for RAII

### DIFF
--- a/src/include/kytea/corpus-io-eda.h
+++ b/src/include/kytea/corpus-io-eda.h
@@ -13,7 +13,7 @@ public:
     EdaCorpusIO(StringUtil * util, const char* file, bool out);
     EdaCorpusIO(StringUtil * util, std::iostream & str, bool out);
     
-    KyteaSentence * readSentence() override;
+    std::unique_ptr<KyteaSentence> readSentence() override;
     void writeSentence(const KyteaSentence * sent, double conf = 0.0) override;
 
 protected:

--- a/src/include/kytea/corpus-io-full.h
+++ b/src/include/kytea/corpus-io-full.h
@@ -20,7 +20,7 @@ public:
     FullCorpusIO(StringUtil * util, const char* file, bool out, const char* wordBound = " ", const char* tagBound = "/", const char* elemBound = "&", const char* escape = "\\");
     FullCorpusIO(StringUtil * util, std::iostream & str, bool out, const char* wordBound = " ", const char* tagBound = "/", const char* elemBound = "&", const char* escape = "\\");
     
-    KyteaSentence * readSentence() override;
+    std::unique_ptr<KyteaSentence> readSentence() override;
     void writeSentence(const KyteaSentence * sent, double conf = 0.0) override;
     void setPrintWords(bool printWords) { printWords_ = printWords; }
 

--- a/src/include/kytea/corpus-io-part.h
+++ b/src/include/kytea/corpus-io-part.h
@@ -27,7 +27,7 @@ public:
     PartCorpusIO(StringUtil * util, std::iostream & str, bool out, const char* unkBound = " ", const char* skipBound = "?", const char* noBound = "-", const char* hasBound = "|", const char* tagBound = "/", const char* elemBound = "&", const char* escape = "\\");
     PartCorpusIO(StringUtil * util, const char* file, bool out, const char* unkBound = " ", const char* skipBound = "?", const char* noBound = "-", const char* hasBound = "|", const char* tagBound = "/", const char* elemBound = "&", const char* escape = "\\");
     
-    KyteaSentence * readSentence() override;
+    std::unique_ptr<KyteaSentence> readSentence() override;
     void writeSentence(const KyteaSentence * sent, double conf = 0.0) override;
 
 };

--- a/src/include/kytea/corpus-io-prob.h
+++ b/src/include/kytea/corpus-io-prob.h
@@ -13,7 +13,7 @@ public:
     ProbCorpusIO(StringUtil * util, const char* file, bool out, const char* wordBound = " ", const char* tagBound = "/", const char* elemBound = "&", const char* escape = "\\") : FullCorpusIO(util,file,out,wordBound,tagBound,elemBound,escape) { allTags_ = true; } 
     ProbCorpusIO(StringUtil * util, std::iostream & str, bool out, const char* wordBound = " ", const char* tagBound = "/", const char* elemBound = "&", const char* escape = "\\") : FullCorpusIO(util,str,out,wordBound,tagBound,elemBound,escape) { allTags_ = true; }
 
-    KyteaSentence * readSentence() override;
+    std::unique_ptr<KyteaSentence> readSentence() override;
     void writeSentence(const KyteaSentence * sent, double conf = 0.0) override;
 
 };

--- a/src/include/kytea/corpus-io-raw.h
+++ b/src/include/kytea/corpus-io-raw.h
@@ -13,7 +13,7 @@ public:
     RawCorpusIO(StringUtil * util, const char* file, bool out) : CorpusIO(util,file,out) { } 
     RawCorpusIO(StringUtil * util, std::iostream & str, bool out) : CorpusIO(util,str,out) { }
 
-    KyteaSentence * readSentence() override;
+    std::unique_ptr<KyteaSentence> readSentence() override;
     void writeSentence(const KyteaSentence * sent, double conf = 0.0) override;
 
 };

--- a/src/include/kytea/corpus-io-tokenized.h
+++ b/src/include/kytea/corpus-io-tokenized.h
@@ -20,7 +20,7 @@ public:
     TokenizedCorpusIO(StringUtil * util, const char* file, bool out, const char* wordBound = " ");
     TokenizedCorpusIO(StringUtil * util, std::iostream & str, bool out, const char* wordBound = " ");
     
-    KyteaSentence * readSentence() override;
+    std::unique_ptr<KyteaSentence> readSentence() override;
     void writeSentence(const KyteaSentence * sent, double conf = 0.0) override;
 
 };

--- a/src/include/kytea/corpus-io.h
+++ b/src/include/kytea/corpus-io.h
@@ -19,6 +19,7 @@
 
 #include <kytea/corpus-io-format.h>
 #include <kytea/general-io.h>
+#include <memory>
 #include <vector>
 
 namespace kytea {
@@ -56,7 +57,7 @@ public:
     static CorpusIO* createIO(const char* file, CorpusFormat form, const KyteaConfig & conf, bool output, StringUtil* util);
     static CorpusIO* createIO(std::iostream & str, CorpusFormat form, const KyteaConfig & conf, bool output, StringUtil* util);
 
-    virtual KyteaSentence * readSentence() = 0;
+    virtual std::unique_ptr<KyteaSentence> readSentence() = 0;
     virtual void writeSentence(const KyteaSentence * sent, double conf = 0.0) = 0;
 
     void setUnkTag(const std::string & tag) { unkTag_ = tag; }

--- a/src/include/kytea/kytea.h
+++ b/src/include/kytea/kytea.h
@@ -19,6 +19,7 @@
 
 #include <kytea/kytea-config.h>
 #include <kytea/kytea-struct.h>
+#include <memory>
 #include <vector>
 
 namespace kytea  {
@@ -39,13 +40,12 @@ class Kytea {
 private:
     friend class KyteaTest;
     typedef unsigned FeatureId;
-    typedef std::vector<KyteaSentence*> Sentences;
     typedef std::vector< std::vector< FeatureId > > SentenceFeatures;
 
     StringUtil* util_;
     KyteaConfig* config_;
     Dictionary<ModelTagEntry> * dict_;
-    Sentences sentences_;
+    std::vector<std::unique_ptr<KyteaSentence>> sentences_;
 
     // Values for the word segmentation models
     KyteaModel* wsModel_;

--- a/src/lib/corpus-io-eda.cpp
+++ b/src/lib/corpus-io-eda.cpp
@@ -12,9 +12,9 @@
 using namespace kytea;
 using namespace std;
 
-KyteaSentence * EdaCorpusIO::readSentence() {
+std::unique_ptr<KyteaSentence> EdaCorpusIO::readSentence() {
     THROW_ERROR("Using EDA format for input is not currently supported");
-    return NULL;
+    return nullptr;
 }
 
 void EdaCorpusIO::writeSentence(const KyteaSentence * sent, double conf) {

--- a/src/lib/corpus-io-full.cpp
+++ b/src/lib/corpus-io-full.cpp
@@ -12,7 +12,7 @@
 using namespace kytea;
 using namespace std;
 
-KyteaSentence * FullCorpusIO::readSentence() {
+std::unique_ptr<KyteaSentence> FullCorpusIO::readSentence() {
 #ifdef KYTEA_SAFE
     if(out_ || !str_) 
         THROW_ERROR("Attempted to read a sentence from an closed or output object");
@@ -20,12 +20,12 @@ KyteaSentence * FullCorpusIO::readSentence() {
     string s;
     getline(*str_, s);
     if(str_->eof())
-        return 0;
+        return nullptr;
 
     KyteaChar spaceChar = bounds_[0], slashChar = bounds_[1], ampChar = bounds_[2], bsChar = bounds_[3];
     KyteaString ks = util_->mapString(s), buff(ks.length());
     int len = ks.length();
-    KyteaSentence * ret = new KyteaSentence();
+    auto ret = std::make_unique<KyteaSentence>();
     int charLen = 0;
 
     // go through the whole string

--- a/src/lib/corpus-io-part.cpp
+++ b/src/lib/corpus-io-part.cpp
@@ -12,7 +12,7 @@
 using namespace kytea;
 using namespace std;
 
-KyteaSentence * PartCorpusIO::readSentence() {
+std::unique_ptr<KyteaSentence> PartCorpusIO::readSentence() {
 #ifdef KYTEA_SAFE
     if(out_ || !str_) 
         THROW_ERROR("Attempted to read a sentence from an closed or output object");
@@ -20,12 +20,12 @@ KyteaSentence * PartCorpusIO::readSentence() {
     string s;
     getline(*str_, s);
     if(str_->eof())
-        return 0;
+        return nullptr;
     KyteaString ks = util_->mapString(s), buff(ks.length());
     KyteaChar ukBound = bounds_[0], skipBound = bounds_[1], noBound = bounds_[2], 
         hasBound = bounds_[3], slashChar = bounds_[4], elemChar = bounds_[5], 
         escapeChar = bounds_[6];
-    KyteaSentence * ret = new KyteaSentence();
+    auto ret = std::make_unique<KyteaSentence>();
 
     int len = ks.length(), charLen = 0;
     for(int j = 0; j < len; j++) {

--- a/src/lib/corpus-io-prob.cpp
+++ b/src/lib/corpus-io-prob.cpp
@@ -13,14 +13,14 @@
 using namespace kytea;
 using namespace std;
 
-KyteaSentence * ProbCorpusIO::readSentence() {
+std::unique_ptr<KyteaSentence> ProbCorpusIO::readSentence() {
 #ifdef KYTEA_SAFE
     if(out_ || !str_) 
         THROW_ERROR("Attempted to read a sentence from an closed or output object");
 #endif
-    KyteaSentence* ret = FullCorpusIO::readSentence();
-    if(ret == 0)
-        return 0;
+    std::unique_ptr<KyteaSentence> ret = FullCorpusIO::readSentence();
+    if (!ret)
+        return nullptr;
     // get the ws confidences
     string s;
     getline(*str_, s);

--- a/src/lib/corpus-io-raw.cpp
+++ b/src/lib/corpus-io-raw.cpp
@@ -11,7 +11,7 @@
 using namespace kytea;
 using namespace std;
 
-KyteaSentence * RawCorpusIO::readSentence() {
+std::unique_ptr<KyteaSentence> RawCorpusIO::readSentence() {
 #ifdef KYTEA_SAFE
     if(out_ || !str_) 
         THROW_ERROR("Attempted to read a sentence from an closed or output object");
@@ -19,8 +19,8 @@ KyteaSentence * RawCorpusIO::readSentence() {
     string s;
     getline(*str_, s);
     if(str_->eof())
-        return 0;
-    KyteaSentence * ret = new KyteaSentence();
+        return nullptr;
+    auto ret = std::make_unique<KyteaSentence>();
     ret->surface = util_->mapString(s);
     ret->norm = util_->normalize(ret->surface);
     if(ret->surface.length() != 0)

--- a/src/lib/corpus-io-tokenized.cpp
+++ b/src/lib/corpus-io-tokenized.cpp
@@ -12,7 +12,7 @@
 using namespace kytea;
 using namespace std;
 
-KyteaSentence * TokenizedCorpusIO::readSentence() {
+std::unique_ptr<KyteaSentence> TokenizedCorpusIO::readSentence() {
 #ifdef KYTEA_SAFE
     if(out_ || !str_) 
         THROW_ERROR("Attempted to read a sentence from an closed or output object");
@@ -20,12 +20,12 @@ KyteaSentence * TokenizedCorpusIO::readSentence() {
     string s;
     getline(*str_, s);
     if(str_->eof())
-        return 0;
+        return nullptr;
 
     KyteaChar spaceChar = bounds_[0];
     KyteaString ks = util_->mapString(s), buff(ks.length());
     int len = ks.length();
-    KyteaSentence * ret = new KyteaSentence();
+    auto ret = std::make_unique<KyteaSentence>();
     int charLen = 0;
 
     // go through the whole string

--- a/src/test/test-analysis.h
+++ b/src/test/test-analysis.h
@@ -316,12 +316,11 @@ public:
         stringstream instr;
         instr << "こ|れ-は デ ー タ で-す 。" << endl;
         PartCorpusIO io(util, instr, false);
-        KyteaSentence * sent = io.readSentence();
+        std::unique_ptr<KyteaSentence> sent = io.readSentence();
         kytea->calculateWS(*sent);
         // Make the correct words
         KyteaString::Tokens toks = util->mapString("こ れは データ です 。").tokenize(util->mapString(" "));
         int ok = checkWordSeg(*sent,toks,util);
-        delete sent;
         return ok;
     }
 
@@ -331,13 +330,13 @@ public:
         stringstream instr;
         instr << confident_text;
         FullCorpusIO infcio(util, instr, false);
-        KyteaSentence * sent = infcio.readSentence();
+        std::unique_ptr<KyteaSentence> sent = infcio.readSentence();
         // Calculate the WS
         kytea->calculateWS(*sent);
         // Write out the sentence
         stringstream outstr1;
         FullCorpusIO outfcio1(util, outstr1, true);
-        outfcio1.writeSentence(sent);
+        outfcio1.writeSentence(sent.get());
         string actual_text = outstr1.str();
         if(actual_text != confident_text) {
             cout << "WS: actual_text != confident_text"<<endl<<" "<<actual_text<<endl<<" "<<confident_text<<endl;
@@ -349,9 +348,8 @@ public:
         // Write out the sentence
         stringstream outstr2;
         FullCorpusIO outfcio2(util, outstr2, true);
-        outfcio2.writeSentence(sent);
+        outfcio2.writeSentence(sent.get());
         actual_text = outstr2.str();
-        delete sent;
         if(actual_text != confident_text) {
             cout << "Tag: actual_text != confident_text"<<endl<<" "<<actual_text<<endl<<" "<<confident_text<<endl;
             return 0;

--- a/src/test/test-corpusio-euc.h
+++ b/src/test/test-corpusio-euc.h
@@ -28,13 +28,11 @@ public:
         // instr << "こ|れ-は デ ー タ で-す 。" << endl;
         instr << "\xa4\xb3\x7c\xa4\xec\x2d\xa4\xcf\x20\xa5\xc7\x20\xa1\xbc\x20\xa5\xbf\x20\xa4\xc7\x2d\xa4\xb9\x20\xa1\xa3" << endl;
         PartCorpusIO io(util, instr, false);
-        KyteaSentence * sent = io.readSentence();
+        std::unique_ptr<KyteaSentence> sent = io.readSentence();
         // Build the expectations
         vector<double> exp(8,0.0);
         exp[0] = 100; exp[1] = -100; exp[6] = -100;
-        bool ret = checkVector(exp, sent->wsConfs); 
-        delete sent;
-        return ret;
+        return checkVector(exp, sent->wsConfs);
     }
 
     int testPartEmptyLines() {
@@ -42,12 +40,10 @@ public:
         stringstream instr;
         instr << "" << endl;
         PartCorpusIO io(util, instr, false);
-        KyteaSentence * sent = io.readSentence();
+        std::unique_ptr<KyteaSentence> sent = io.readSentence();
         // Build the expectations
         vector<double> exp(0,0.0);
-        bool ret = checkVector(exp, sent->wsConfs); 
-        delete sent;
-        return ret;
+        return checkVector(exp, sent->wsConfs);
     }
 
     int testPartEmptyTag() {
@@ -56,13 +52,12 @@ public:
         // instr << "こ-れ//これ" << endl;
         instr << "\xa4\xb3\x2d\xa4\xec\x2f\x2f\xa4\xb3\xa4\xec" << endl;
         PartCorpusIO io(util, instr, false);
-        KyteaSentence * sent = io.readSentence();
+        std::unique_ptr<KyteaSentence> sent = io.readSentence();
         int ret = 1;
         if(sent->words.size() != 1) {
             cerr << "Sentence size " << sent->words.size() << " != 1" << endl;
             ret = 0;
         }
-        delete sent;
         return ret;
     }
 
@@ -72,7 +67,7 @@ public:
         // instr << "こ-れ/名詞 は/助詞 データ/名詞 で/助動詞 す/語尾 。/補助記号" << endl;
         instr << "\xa4\xb3\x2d\xa4\xec\x2f\xcc\xbe\xbb\xec\x20\xa4\xcf\x2f\xbd\xf5\xbb\xec\x20\xa5\xc7\xa1\xbc\xa5\xbf\x2f\xcc\xbe\xbb\xec\x20\xa4\xc7\x2f\xbd\xf5\xc6\xb0\xbb\xec\x20\xa4\xb9\x2f\xb8\xec\xc8\xf8\x20\xa1\xa3\x2f\xca\xe4\xbd\xf5\xb5\xad\xb9\xe6" << endl;
         FullCorpusIO io(util, instr, false);
-        KyteaSentence * sent = io.readSentence();
+        std::unique_ptr<KyteaSentence> sent = io.readSentence();
         // Build the expectations
         if(sent->words.size() != 6)
             THROW_ERROR("sent->words size doesn't match 5 " << sent->words.size());
@@ -83,7 +78,6 @@ public:
                 ret = false;
             }
         }
-        delete sent;
         return ret;
     }
 
@@ -94,7 +88,7 @@ public:
         stringstream instr;
         instr << confident_text;
         FullCorpusIO infcio(util, instr, false);
-        KyteaSentence * sent = infcio.readSentence();
+        std::unique_ptr<KyteaSentence> sent = infcio.readSentence();
         int ret = 1;
         if(sent->words.size() != 11) {
             cerr << "Did not get expected sentence size of 11: " << sent->words.size() << endl;
@@ -103,7 +97,6 @@ public:
             cerr << "Did not get two levels of tags for final word: " << sent->words[10].tags.size() << endl;
             ret = 0;
         }
-        delete sent;
         return ret;
     }
     
@@ -114,16 +107,15 @@ public:
         stringstream instr;
         instr << input;
         FullCorpusIO infcio(util, instr, false);
-        KyteaSentence * sent = infcio.readSentence();
+        std::unique_ptr<KyteaSentence> sent = infcio.readSentence();
         sent->words[2].setUnknown(true);
         // string exp = "これ/代名詞/これ は/助詞/は 未知/名詞/みち/UNK\n";
         string exp = "\xa4\xb3\xa4\xec\x2f\xc2\xe5\xcc\xbe\xbb\xec\x2f\xa4\xb3\xa4\xec\x20\xa4\xcf\x2f\xbd\xf5\xbb\xec\x2f\xa4\xcf\x20\xcc\xa4\xc3\xce\x2f\xcc\xbe\xbb\xec\x2f\xa4\xdf\xa4\xc1\x2f\x55\x4e\x4b\n";
         stringstream outstr;
         FullCorpusIO outfcio(util, outstr, true);
         outfcio.setUnkTag("/UNK");
-        outfcio.writeSentence(sent);
+        outfcio.writeSentence(sent.get());
         string act = outstr.str();
-        delete sent;
         if(exp != act) {
             cerr << "exp: "<<exp<<endl<<"act: "<<act<<endl;
             return 0;

--- a/src/test/test-corpusio-sjis.h
+++ b/src/test/test-corpusio-sjis.h
@@ -28,13 +28,11 @@ public:
         // instr << "こ|れ-は デ ー タ で-す 。" << endl;
         instr << "\x82\xb1\x7c\x82\xea\x2d\x82\xcd\x20\x83\x66\x20\x81\x5b\x20\x83\x5e\x20\x82\xc5\x2d\x82\xb7\x20\x81\x42" << endl;
         PartCorpusIO io(util, instr, false);
-        KyteaSentence * sent = io.readSentence();
+        std::unique_ptr<KyteaSentence> sent = io.readSentence();
         // Build the expectations
         vector<double> exp(8,0.0);
         exp[0] = 100; exp[1] = -100; exp[6] = -100;
-        bool ret = checkVector(exp, sent->wsConfs); 
-        delete sent;
-        return ret;
+        return checkVector(exp, sent->wsConfs);
     }
 
     int testPartEmptyLines() {
@@ -42,12 +40,10 @@ public:
         stringstream instr;
         instr << "" << endl;
         PartCorpusIO io(util, instr, false);
-        KyteaSentence * sent = io.readSentence();
+        std::unique_ptr<KyteaSentence> sent = io.readSentence();
         // Build the expectations
         vector<double> exp(0,0.0);
-        bool ret = checkVector(exp, sent->wsConfs); 
-        delete sent;
-        return ret;
+        return checkVector(exp, sent->wsConfs);
     }
 
     int testPartEmptyTag() {
@@ -56,13 +52,12 @@ public:
         // instr << "こ-れ//これ" << endl;
         instr << "\x82\xb1\x2d\x82\xea\x2f\x2f\x82\xb1\x82\xea" << endl;
         PartCorpusIO io(util, instr, false);
-        KyteaSentence * sent = io.readSentence();
+        std::unique_ptr<KyteaSentence> sent = io.readSentence();
         int ret = 1;
         if(sent->words.size() != 1) {
             cerr << "Sentence size " << sent->words.size() << " != 1" << endl;
             ret = 0;
         }
-        delete sent;
         return ret;
     }
 
@@ -72,7 +67,7 @@ public:
         // instr << "こ-れ/名詞 は/助詞 データ/名詞 で/助動詞 す/語尾 。/補助記号" << endl;
         instr << "\x82\xb1\x2d\x82\xea\x2f\x96\xbc\x8e\x8c\x20\x82\xcd\x2f\x8f\x95\x8e\x8c\x20\x83\x66\x81\x5b\x83\x5e\x2f\x96\xbc\x8e\x8c\x20\x82\xc5\x2f\x8f\x95\x93\xae\x8e\x8c\x20\x82\xb7\x2f\x8c\xea\x94\xf6\x20\x81\x42\x2f\x95\xe2\x8f\x95\x8b\x4c\x8d\x86" << endl;
         FullCorpusIO io(util, instr, false);
-        KyteaSentence * sent = io.readSentence();
+        std::unique_ptr<KyteaSentence> sent = io.readSentence();
         // Build the expectations
         if(sent->words.size() != 6)
             THROW_ERROR("sent->words size doesn't match 5 " << sent->words.size());
@@ -83,7 +78,6 @@ public:
                 ret = false;
             }
         }
-        delete sent;
         return ret;
     }
 
@@ -94,7 +88,7 @@ public:
         stringstream instr;
         instr << confident_text;
         FullCorpusIO infcio(util, instr, false);
-        KyteaSentence * sent = infcio.readSentence();
+        std::unique_ptr<KyteaSentence> sent = infcio.readSentence();
         int ret = 1;
         if(sent->words.size() != 11) {
             cerr << "Did not get expected sentence size of 11: " << sent->words.size() << endl;
@@ -103,7 +97,6 @@ public:
             cerr << "Did not get two levels of tags for final word: " << sent->words[10].tags.size() << endl;
             ret = 0;
         }
-        delete sent;
         return ret;
     }
     
@@ -114,16 +107,15 @@ public:
         stringstream instr;
         instr << input;
         FullCorpusIO infcio(util, instr, false);
-        KyteaSentence * sent = infcio.readSentence();
+        std::unique_ptr<KyteaSentence> sent = infcio.readSentence();
         sent->words[2].setUnknown(true);
         // string exp = "これ/代名詞/これ は/助詞/は 未知/名詞/みち/UNK\n";
         string exp = "\x82\xb1\x82\xea\x2f\x91\xe3\x96\xbc\x8e\x8c\x2f\x82\xb1\x82\xea\x20\x82\xcd\x2f\x8f\x95\x8e\x8c\x2f\x82\xcd\x20\x96\xa2\x92\x6d\x2f\x96\xbc\x8e\x8c\x2f\x82\xdd\x82\xbf\x2f\x55\x4e\x4b\n";
         stringstream outstr;
         FullCorpusIO outfcio(util, outstr, true);
         outfcio.setUnkTag("/UNK");
-        outfcio.writeSentence(sent);
+        outfcio.writeSentence(sent.get());
         string act = outstr.str();
-        delete sent;
         if(exp != act) {
             cerr << "exp: "<<exp<<endl<<"act: "<<act<<endl;
             return 0;

--- a/src/test/test-sentence.h
+++ b/src/test/test-sentence.h
@@ -26,7 +26,7 @@ public:
         stringstream instr;
         instr << "これ は データ/名詞 で/助動詞 す/語尾 。" << endl;
         FullCorpusIO io(util, instr, false);
-        KyteaSentence * sent = io.readSentence();
+        std::unique_ptr<KyteaSentence> sent = io.readSentence();
         // Refresh the word segmentation
         sent->wsConfs[6] = -100;
         sent->refreshWS(1);
@@ -35,7 +35,6 @@ public:
         KyteaString::Tokens tags = util->mapString("NONE NONE 名詞 NONE NONE").tokenize(util->mapString(" "));
         bool wordsOK = checkWordSeg(*sent,words,util); 
         bool tagsOK = checkTags(*sent,tags,0,util); 
-        delete sent;
         return wordsOK && tagsOK;
     }
 


### PR DESCRIPTION
This replaces the return type of `readSentence` from a raw pointer to `std::unique_ptr`.

* For RAII. No need to manually delete the allocated objects any more.
* The use of `std::unique_ptr` clarifies the ownership (which class owns the objects).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/neubig/kytea/37)
<!-- Reviewable:end -->
