### PR TITLE
Fix the bug introduced in PR #31

### DIFF
--- a/src/lib/corpus-io.cpp
+++ b/src/lib/corpus-io.cpp
@@ -70,9 +70,9 @@ CorpusIO * CorpusIO::createIO(const char* file, CorpusFormat form, const KyteaCo
 CorpusIO * CorpusIO::createIO(iostream & file, CorpusFormat form, const KyteaConfig & conf, bool output, StringUtil* util) {
     switch (form) {
         case CORP_FORMAT_FULL:
-            new FullCorpusIO(util, file, output, conf.getWordBound(),
-                             conf.getTagBound(), conf.getElemBound(),
-                             conf.getEscape());
+            return new FullCorpusIO(util, file, output, conf.getWordBound(),
+                                    conf.getTagBound(), conf.getElemBound(),
+                                    conf.getEscape());
         case CORP_FORMAT_TAGS: {
             FullCorpusIO* io = new FullCorpusIO(
                 util, file, output, conf.getWordBound(), conf.getTagBound(),


### PR DESCRIPTION
This fixes the bug introduced in PR #31.
CorpusIO::createIO doesn't return allocated FullCorpusIO objects. The PR accidentally dropped `return`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/neubig/kytea/38)
<!-- Reviewable:end -->
