### PR TITLE
Change CorpusIO::createIO to return std::unique_ptr

### DIFF
--- a/src/include/kytea/corpus-io.h
+++ b/src/include/kytea/corpus-io.h
@@ -19,6 +19,7 @@
 
 #include <kytea/corpus-io-format.h>
 #include <kytea/general-io.h>
+#include <memory>
 #include <vector>
 
 namespace kytea {
@@ -53,8 +54,14 @@ public:
     virtual ~CorpusIO() { }
 
     // create an appropriate parser based on the type
-    static CorpusIO* createIO(const char* file, CorpusFormat form, const KyteaConfig & conf, bool output, StringUtil* util);
-    static CorpusIO* createIO(std::iostream & str, CorpusFormat form, const KyteaConfig & conf, bool output, StringUtil* util);
+    static std::unique_ptr<CorpusIO> createIO(const char* file,
+                                              CorpusFormat form,
+                                              const KyteaConfig& conf,
+                                              bool output, StringUtil* util);
+    static std::unique_ptr<CorpusIO> createIO(std::iostream& str,
+                                              CorpusFormat form,
+                                              const KyteaConfig& conf,
+                                              bool output, StringUtil* util);
 
     virtual KyteaSentence * readSentence() = 0;
     virtual void writeSentence(const KyteaSentence * sent, double conf = 0.0) = 0;

--- a/src/lib/corpus-io.cpp
+++ b/src/lib/corpus-io.cpp
@@ -70,9 +70,9 @@ CorpusIO * CorpusIO::createIO(const char* file, CorpusFormat form, const KyteaCo
 CorpusIO * CorpusIO::createIO(iostream & file, CorpusFormat form, const KyteaConfig & conf, bool output, StringUtil* util) {
     switch (form) {
         case CORP_FORMAT_FULL:
-            new FullCorpusIO(util, file, output, conf.getWordBound(),
-                             conf.getTagBound(), conf.getElemBound(),
-                             conf.getEscape());
+            return new FullCorpusIO(util, file, output, conf.getWordBound(),
+                                    conf.getTagBound(), conf.getElemBound(),
+                                    conf.getEscape());
         case CORP_FORMAT_TAGS: {
             FullCorpusIO* io = new FullCorpusIO(
                 util, file, output, conf.getWordBound(), conf.getTagBound(),

--- a/src/lib/corpus-io.cpp
+++ b/src/lib/corpus-io.cpp
@@ -33,70 +33,75 @@
 using namespace kytea;
 using namespace std;
 
-CorpusIO * CorpusIO::createIO(const char* file, CorpusFormat form, const KyteaConfig & conf, bool output, StringUtil* util) {
+std::unique_ptr<CorpusIO> CorpusIO::createIO(const char* file,
+                                             CorpusFormat form,
+                                             const KyteaConfig& conf,
+                                             bool output, StringUtil* util) {
     switch (form) {
         case CORP_FORMAT_FULL:
-            return new FullCorpusIO(util, file, output, conf.getWordBound(),
-                                    conf.getTagBound(), conf.getElemBound(),
-                                    conf.getEscape());
+            return std::make_unique<FullCorpusIO>(
+                util, file, output, conf.getWordBound(), conf.getTagBound(),
+                conf.getElemBound(), conf.getEscape());
         case CORP_FORMAT_TAGS: {
-            FullCorpusIO* io = new FullCorpusIO(
+            auto io = std::make_unique<FullCorpusIO>(
                 util, file, output, conf.getWordBound(), conf.getTagBound(),
                 conf.getElemBound(), conf.getEscape());
             io->setPrintWords(false);
-            return io;
+            return std::move(io);
         }
         case CORP_FORMAT_TOK:
-            return new TokenizedCorpusIO(util, file, output,
-                                         conf.getWordBound());
+            return std::make_unique<TokenizedCorpusIO>(util, file, output,
+                                                       conf.getWordBound());
         case CORP_FORMAT_PART:
-            return new PartCorpusIO(util, file, output, conf.getUnkBound(),
-                                    conf.getSkipBound(), conf.getNoBound(),
-                                    conf.getHasBound(), conf.getTagBound(),
-                                    conf.getElemBound(), conf.getEscape());
+            return std::make_unique<PartCorpusIO>(
+                util, file, output, conf.getUnkBound(), conf.getSkipBound(),
+                conf.getNoBound(), conf.getHasBound(), conf.getTagBound(),
+                conf.getElemBound(), conf.getEscape());
         case CORP_FORMAT_PROB:
-            return new ProbCorpusIO(util, file, output, conf.getWordBound(),
-                                    conf.getTagBound(), conf.getElemBound(),
-                                    conf.getEscape());
+            return std::make_unique<ProbCorpusIO>(
+                util, file, output, conf.getWordBound(), conf.getTagBound(),
+                conf.getElemBound(), conf.getEscape());
         case CORP_FORMAT_RAW:
-            return new RawCorpusIO(util, file, output);
+            return std::make_unique<RawCorpusIO>(util, file, output);
         case CORP_FORMAT_EDA:
-            return new EdaCorpusIO(util, file, output);
+            return std::make_unique<EdaCorpusIO>(util, file, output);
         default:
             THROW_ERROR("Illegal Output Format");
     }
 }
 
-CorpusIO * CorpusIO::createIO(iostream & file, CorpusFormat form, const KyteaConfig & conf, bool output, StringUtil* util) {
+std::unique_ptr<CorpusIO> CorpusIO::createIO(iostream& file, CorpusFormat form,
+                                             const KyteaConfig& conf,
+                                             bool output, StringUtil* util) {
     switch (form) {
         case CORP_FORMAT_FULL:
-            return new FullCorpusIO(util, file, output, conf.getWordBound(),
+            return std::make_unique<FullCorpusIO>(util, file, output, conf.getWordBound(),
                                     conf.getTagBound(), conf.getElemBound(),
                                     conf.getEscape());
         case CORP_FORMAT_TAGS: {
-            FullCorpusIO* io = new FullCorpusIO(
+            auto io = std::make_unique<FullCorpusIO>(
                 util, file, output, conf.getWordBound(), conf.getTagBound(),
                 conf.getElemBound(), conf.getEscape());
             io->setPrintWords(false);
-            return io;
+            return std::move(io);
         }
         case CORP_FORMAT_TOK:
-            return new TokenizedCorpusIO(util, file, output,
-                                         conf.getWordBound());
+            return std::make_unique<TokenizedCorpusIO>(util, file, output,
+                                                       conf.getWordBound());
         case CORP_FORMAT_PART:
-            return new PartCorpusIO(util, file, output, conf.getUnkBound(),
-                                    conf.getSkipBound(), conf.getNoBound(),
-                                    conf.getHasBound(), conf.getTagBound(),
-                                    conf.getElemBound(), conf.getEscape());
+            return std::make_unique<PartCorpusIO>(
+                util, file, output, conf.getUnkBound(), conf.getSkipBound(),
+                conf.getNoBound(), conf.getHasBound(), conf.getTagBound(),
+                conf.getElemBound(), conf.getEscape());
 
         case CORP_FORMAT_PROB:
-            return new ProbCorpusIO(util, file, output, conf.getWordBound(),
-                                    conf.getTagBound(), conf.getElemBound(),
-                                    conf.getEscape());
+            return std::make_unique<ProbCorpusIO>(
+                util, file, output, conf.getWordBound(), conf.getTagBound(),
+                conf.getElemBound(), conf.getEscape());
         case CORP_FORMAT_RAW:
-            return new RawCorpusIO(util, file, output);
+            return std::make_unique<RawCorpusIO>(util, file, output);
         case CORP_FORMAT_EDA:
-            return new EdaCorpusIO(util, file, output);
+            return std::make_unique<EdaCorpusIO>(util, file, output);
         default:
             THROW_ERROR("Illegal Output Format");
     }

--- a/src/lib/kytea.cpp
+++ b/src/lib/kytea.cpp
@@ -92,7 +92,8 @@ void Kytea::scanDictionaries(const vector<string> & dict, typename Dictionary<En
     for(vector<string>::const_iterator it = dict.begin(); it != dict.end(); it++) {
         if(config_->getDebug())
             cerr << "Reading dictionary from " << *it << " ";
-        CorpusIO * io = CorpusIO::createIO(it->c_str(), CORP_FORMAT_FULL, *config, false, util);
+        std::unique_ptr<CorpusIO> io = CorpusIO::createIO(
+            it->c_str(), CORP_FORMAT_FULL, *config, false, util);
         io->setNumTags(config_->getNumTags());
         KyteaSentence* next;
         int lines = 0;
@@ -116,7 +117,6 @@ void Kytea::scanDictionaries(const vector<string> & dict, typename Dictionary<En
                 addTag<Entry>(wordMap, word, 0, 0, (saveIds?numDicts:-1));
             delete next;
         }
-        delete io;
         numDicts++;
         if(config_->getDebug() > 0) {
             if(lines)
@@ -141,7 +141,8 @@ void Kytea::buildVocabulary() {
     for(unsigned i = 0; i < corpora.size(); i++) {
         if(config_->getDebug() > 0)
             cerr << "Reading corpus from " << corpora[i] << " ";
-        CorpusIO * io = CorpusIO::createIO(corpora[i].c_str(), corpForm[i], *config_, false, util_);
+        std::unique_ptr<CorpusIO> io = CorpusIO::createIO(
+            corpora[i].c_str(), corpForm[i], *config_, false, util_);
         io->setNumTags(config_->getNumTags());
         KyteaSentence* next;
         int lines = 0;
@@ -174,7 +175,6 @@ void Kytea::buildVocabulary() {
             else
                 cerr << " WARNING - empty training data specified."  << endl;
         }
-        delete io;
     }
     config_->setNumTags(maxTag);
 
@@ -1186,7 +1186,8 @@ void Kytea::analyze() {
     if(config_->getDebug() > 0)    
         cerr << "Analyzing input ";
 
-    CorpusIO *in, *out;
+    std::unique_ptr<CorpusIO> in;
+    std::unique_ptr<CorpusIO> out;
     iostream *inStr = 0, *outStr = 0;
     const vector<string> & args = config_->getArguments();
     if(args.size() > 0) {
@@ -1218,8 +1219,6 @@ void Kytea::analyze() {
         delete next;
     }
 
-    delete in;
-    delete out;
     if(inStr) delete inStr;
     if(outStr) delete outStr;
 


### PR DESCRIPTION
This depends on #38.

This changes CorpusIO::createIO to return std::unique_ptr so that the caller doesn't need to manually delete returned objects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/neubig/kytea/39)
<!-- Reviewable:end -->
